### PR TITLE
Lazily register `setupTeamCityProject` task

### DIFF
--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsPlugin.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsPlugin.groovy
@@ -31,6 +31,6 @@ class GradleUtilsPlugin implements Plugin<Project> {
         ChangelogGenerationExtension changelogGenerationExtension = project.extensions.create("changelog", ChangelogGenerationExtension.class, project)
 
         //Setup the teamcity project task.
-        project.getTasks().create("setupTeamCityProject", ExtractTeamCityProjectConfigurationTask.class);
+        project.getTasks().register("setupTeamCityProject", ExtractTeamCityProjectConfigurationTask.class);
     }
 }


### PR DESCRIPTION
This PR modifies the call used when registering the `setupTeamCityProject` task to use `#register` instead of `#create`. This makes uses of the [task configuration avoidance API][configuration-avoidance] to avoid creating the task until it is required (such as during execution).

[configuration-avoidance]: https://docs.gradle.org/7.3/userguide/task_configuration_avoidance.html