### PR TITLE
Manually create repository instead of using Git.open

### DIFF
--- a/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/ChangelogUtils.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/ChangelogUtils.groovy
@@ -31,6 +31,7 @@ import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevSort
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.revwalk.filter.RevFilter
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.gradle.api.Action
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.Project
@@ -55,7 +56,7 @@ class ChangelogUtils {
      * @return A multiline changelog string.
      */
     static String generateChangelog(final File projectDirectory, final String repositoryUrl, final boolean justText) {
-        def git = Git.open(projectDirectory); //Grab git from the given project directory.
+        def git = Git.wrap(new FileRepositoryBuilder().readEnvironment().findGitDir(projectDirectory).setMustExist(true).build()); //Grab git from the given project directory.
 
         def headCommit = getHead(git); //Grab the head commit.
         def logFromCommit = getMergeBaseCommit(git); //Grab the last merge base commit on the current branch.
@@ -78,7 +79,7 @@ class ChangelogUtils {
      * @return A multiline changelog string.
      */
     static String generateChangelog(final File projectDirectory, final String repositoryUrl, final boolean justText, final String sourceTag) {
-        def git = Git.open(projectDirectory); //Grab git from the given project directory.
+        def git = Git.wrap(new FileRepositoryBuilder().readEnvironment().findGitDir(projectDirectory).setMustExist(true).build()) //Grab git from the given project directory.
 
         def tagMap = getTagToCommitMap(git); //Get the tag to commit map so that the beginning commit can be found.
         if (!tagMap.containsKey(sourceTag)) //Check if it even exists.
@@ -102,7 +103,7 @@ class ChangelogUtils {
      * @return A multiline changelog string.
      */
     static String generateChangelogFromCommit(final File projectDirectory, final String repositoryUrl, final boolean justText, final String commitHash) {
-        def git = Git.open(projectDirectory); //Grab git from the given project directory.
+        def git = Git.wrap(new FileRepositoryBuilder().readEnvironment().findGitDir(projectDirectory).setMustExist(true).build()); //Grab git from the given project directory.
 
         def commit = getCommitFromId(git, ObjectId.fromString(commitHash)) //Grab the start commit.
         def headCommit = getHead(git); //Grab the current head commit.

--- a/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -25,6 +25,7 @@ import org.eclipse.jgit.errors.RepositoryNotFoundException
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.transport.URIish
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.authentication.http.BasicAuthentication
@@ -47,7 +48,7 @@ class GradleUtils {
     static gitInfo(File dir, String... globFilters) {
         def git
         try {
-            git = Git.open(dir)
+            git = Git.wrap(new FileRepositoryBuilder().readEnvironment().findGitDir(dir).setMustExist(true).build())
         } catch (RepositoryNotFoundException e) {
             return [
                     tag: '0.0',
@@ -321,7 +322,7 @@ class GradleUtils {
      * @return
      */
     static String buildProjectUrl(final File projectDir) {
-        Git git = Git.open(projectDir) //Create a git workspace.
+        Git git = Git.wrap(new FileRepositoryBuilder().readEnvironment().findGitDir(projectDir).setMustExist(true).build()) //Create a git workspace.
 
         def remotes = git.remoteList().call() //Get all remotes.
         if (remotes.size() == 0)

--- a/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/tasks/ExtractTeamCityProjectConfigurationTask.java
+++ b/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/tasks/ExtractTeamCityProjectConfigurationTask.java
@@ -22,6 +22,7 @@ package net.minecraftforge.gradleutils.tasks;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.file.DirectoryProperty;
@@ -283,7 +284,7 @@ public abstract class ExtractTeamCityProjectConfigurationTask extends DefaultTas
      */
     private static String determineGitHubProjectName(final File projectDir) throws Exception
     {
-        final Git git = Git.open(projectDir);
+        final Git git = Git.wrap(new FileRepositoryBuilder().readEnvironment().findGitDir(projectDir).setMustExist(true).build());
         final String repositoryPath = git.remoteList().call().get(0).getURIs().get(0).getPath();
 
         return repositoryPath.substring(repositoryPath.lastIndexOf("/") + 1).replace(".git", "");
@@ -298,7 +299,7 @@ public abstract class ExtractTeamCityProjectConfigurationTask extends DefaultTas
      */
     private static String determineGitHubProjectOrganisation(final File projectDir) throws Exception
     {
-        final Git git = Git.open(projectDir);
+        final Git git = Git.wrap(new FileRepositoryBuilder().readEnvironment().findGitDir(projectDir).setMustExist(true).build());
         final String repositoryPath = git.remoteList().call().get(0).getURIs().get(0).getPath();
 
         final String[] pathMembers = repositoryPath.split("/");


### PR DESCRIPTION
Currently, GradleUtils uses `Git#open` when opening the git repository for access in code. However, this suffers from a flaw: because `Git#open` internally uses `BaseRepositoryBuilder#setGitDir`, which means that the passed in directory to `Git#open` is the actual repository (or the git metadata folder therefore), it is unable to handle [separate worktrees][worktrees] (whose `.git` is a file that contains the path to the actual repository).

This PR replaces the uses of `Git.open` with a manual creation of a `Repository` instance passed into `Git.wrap`. The repository instance uses `findGitDir` instead of `setGitDir`, allowing it to handle worktrees automatically by following the path within the `.git` file (and even work if the project directory passed in were a sub-directory of the actual git repository).

Note that there is another issue that has existed before this PR: the `Repository` instance in `Git` is not closed (either via `Git#close` when opened via `Git#open`, or calling `#close` on the repository instance itself when using `Git#wrap`), which may potentially cause leaks. Because of the refactoring complexity needed to fix the errors, I've decided to omit fixing that for now.

[worktrees]: https://git-scm.com/docs/git-worktree