### PR TITLE
Fix changelog generation going through all commits

### DIFF
--- a/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/ChangelogUtils.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/ChangelogUtils.groovy
@@ -330,8 +330,7 @@ class ChangelogUtils {
         for (RevCommit parent : start.getParents()) {
             log.not(parent)
         }
-        // In the other case where our commit does _not_ have a parent (i.e. it is the 'root' commit),
-        // we do _not_ exclude it so it is present in the returned iterable
+        // We do not exclude the starting commit itself, so the commit is present in the returned iterable
 
         return log.call()
     }

--- a/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/ChangelogUtils.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/gradleutils/ChangelogUtils.groovy
@@ -324,7 +324,16 @@ class ChangelogUtils {
      * @return The commit log.
      */
     private static Iterable<RevCommit> getCommitLogFromTo(final Git git, final RevCommit start, final RevCommit end) {
-        return git.log().add(start.getParentCount() > 0 ? start.getParent(0).toObjectId() : start.toObjectId()).add(end.toObjectId()).call();
+        def log = git.log().add(end)
+
+        // If our starting commit contains at least one parent (it is not the 'root' commit), exclude all of those parents
+        for (RevCommit parent : start.getParents()) {
+            log.not(parent)
+        }
+        // In the other case where our commit does _not_ have a parent (i.e. it is the 'root' commit),
+        // we do _not_ exclude it so it is present in the returned iterable
+
+        return log.call()
     }
 
     /**


### PR DESCRIPTION
PR #9 erroneously changed the call from `addRange(start, end)` to two calls of `add(start).add(end)`. Where the former's equivalent in the command line would be `git log start..end` (`git log end --not start`), the latter's equivalent would be `git log start end`. 

This meant that instead of listing those commits between (and including) the start and end commits, it listed all commits which were reachable by both start and end commits.

This PR fixes that by amending the logic in `getCommitLogFromTo` based on these two ideas:

 1. Calling `.not(commit)` (`--not commit`) excludes that commit and its ancestors from the resulting list of commits.
 2. A root commit -- that is, the 'initial' commit of the repository -- does not have any ancestors.

We include in the list the end commit and its ancestors, as normal. We then exclude any _parents_ of the starting commit (that is, the commit we wish to include in the list but none of its ancestors), instead of the starting commit itself (which would exclude the starting commit from the list, which is not desired behavior).

By excluding the parents of the starting commit instead of the commit itself, we allow the starting commit to remain in the list. Furthermore, as we silently handle when the commit has no parents, we handle the case where the starting commit is a root commit (which is the original intention behind PR #9).