### PR TITLE
Introduce subproject isolation for versioning and changelogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.yaml:snakeyaml:2.4'
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-gradle-plugin'
     id 'groovy'
+    id 'idea'
     id 'maven-publish'
     id 'net.minecraftforge.licenser' version '1.0.1'
     id 'com.gradle.plugin-publish' version '1.2.1'
@@ -96,4 +97,8 @@ publishing {
     repositories {
         maven gradleutils.publishingForgeMaven
     }
+}
+
+idea.module {
+    downloadSources = downloadJavadoc = true
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,6 +10,7 @@ repositories {
 java.toolchain.languageVersion = JavaLanguageVersion.of(11)
 
 dependencies {
+    implementation 'org.yaml:snakeyaml:2.4'
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r'
 }
 

--- a/src/main/groovy/net/minecraftforge/gradleutils/GenerateActionsWorkflow.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GenerateActionsWorkflow.groovy
@@ -1,0 +1,102 @@
+package net.minecraftforge.gradleutils
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.yaml.snakeyaml.DumperOptions
+import org.yaml.snakeyaml.Yaml
+
+abstract class GenerateActionsWorkflow extends DefaultTask {
+    private static final String DEFAULT_NAME = 'generateActionsWorkflow'
+
+    static TaskProvider<GenerateActionsWorkflow> register(Project project) {
+        return register(project, DEFAULT_NAME)
+    }
+
+    static TaskProvider<GenerateActionsWorkflow> register(Project project, String name) {
+        var task = project.tasks.register(name, GenerateActionsWorkflow)
+
+        // configure artifact
+//        project.configurations.register(name) { canBeResolved = false }
+//        project.artifacts.add(name, task)
+
+        project.plugins.withType(LifecycleBasePlugin) {
+            project.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME).configure {
+                dependsOn(task)
+            }
+        }
+
+        return task
+    }
+
+    GenerateActionsWorkflow() {
+        this.projectPath.convention this.project.provider { GradleUtils.makeFilterFromSubproject(this.project) }
+        this.subprojectFilters.convention this.project.provider { this.project.subprojects.collect { "!${GradleUtils.makeFilterFromSubproject(it)}/**".toString() } }
+        this.tagPrefix.convention this.project.provider { this.project.extensions.getByType(GradleUtilsExtension).gitInfo.tagPrefix }
+    }
+
+    @Input
+    @Optional
+    abstract Property<String> getProjectPath();
+
+    @Input
+    @Optional
+    abstract ListProperty<String> getSubprojectFilters();
+
+    @Input
+    @Optional
+    abstract Property<String> getTagPrefix();
+
+    @TaskAction
+    void exec() throws IOException {
+        def push = ['branches': 'master'] as Map
+
+        var path = this.projectPath.getOrNull()
+        var ignoredPaths = this.subprojectFilters.getOrElse(Collections.emptyList())
+        var tagPrefix = this.tagPrefix.getOrNull()
+        
+        push.put('paths', new ArrayList<String>().tap {
+            if (path) it.add(path + '/**')
+
+            it.add('!settings.gradle')
+            it.addAll(ignoredPaths)
+        })
+
+        def with = [
+            'java': 21,
+            'gradle_tasks': "${path ? ":${path}:" : ''}build".toString()
+        ] as Map
+        if (path) with.put('subproject', path)
+        if (tagPrefix) with.put('tag_prefix', this.tagPrefix.get())
+
+        Map yaml = [
+            'name': 'Build',
+            'on': ['push': push],
+            'permissions': ['contents': 'read'],
+            'jobs': [
+                'build': [
+                    'uses': 'MinecraftForge/SharedActions/.github/workflows/gradle.yml@main',
+                    'with': with,
+                    'secrets': [
+                        'DISCORD_WEBHOOK': '${{ secrets.DISCORD_WEBHOOK }}'
+                    ]
+                ]
+            ]
+        ]
+        var workflow = new Yaml(
+            new DumperOptions().tap {
+                explicitStart = false
+                defaultFlowStyle = DumperOptions.FlowStyle.BLOCK
+                prettyFlow = true
+            }
+        ).dump(yaml).replace("'on':", 'on:')
+
+        logger.lifecycle(workflow)
+    }
+}

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -151,7 +151,7 @@ class GradleUtils {
     }
 
     static Map<String, String> gitInfo(File dir, BiFunction<Git, String, @Nullable Integer> commitCountProvider, @Nullable String tagPrefix, String... globFilters) {
-        println "Getting git info! Dir: $dir, tagPrefix: $tagPrefix, globFilters: [${String.join(', ', globFilters)}]"
+//        println "Getting git info! Dir: $dir, tagPrefix: $tagPrefix, globFilters: [${String.join(', ', globFilters)}]"
 
         var git
         var parent = SystemReader.instance
@@ -184,7 +184,6 @@ class GradleUtils {
         Map<String, String> ret = [:]
         ret.dir = dir.absolutePath
         ret.tag = desc[0]
-        println "Tag: ${ret.tag}"
         if (ret.tag.startsWith("v") && ret.tag.length() > 1 && ret.tag.charAt(1).digit)
             ret.tag = ret.tag.substring(1)
 
@@ -206,7 +205,7 @@ class GradleUtils {
     static @Nullable Integer getSubprojectCommitCount(Git git, String tag, String filter) {
         if (filter === null || filter.isEmpty()) return null
 
-        println "Getting subproject commit count! Tag: $tag, filter: $filter"
+//        println "Getting subproject commit count! Tag: $tag, filter: $filter"
         var tags = getTagToCommitMap(git)
         var commitHash = tags.get(tag)
         var commit = commitHash != null ? ObjectId.fromString(commitHash) : getFirstCommitInRepository(git).toObjectId()

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -168,7 +168,7 @@ class GradleUtils {
             it.long = true
 
             // match isn't an attribute, we can call setMatch() twice since it just adds matches
-            match = tagPrefix ? new String[] { tagPrefix + "**" } : new String[0]
+            if (tagPrefix) match = new String[] { tagPrefix + "**" }
             match = globFilters ?: new String[0]
         }.call()
 

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -118,6 +118,11 @@ class GradleUtils {
         return gitInfo(findGitRoot(project).get().asFile, (git, tag) -> getSubprojectCommitCount(git, tag, makeFilterFromSubproject(project)), globFilters)
     }
 
+    @Deprecated(forRemoval = true, since = "2.3")
+    static Map<String, String> gitInfo(File dir, String... globFilters) {
+        return gitInfo(dir, (git, tag) -> null, globFilters)
+    }
+
     static Map<String, String> gitInfo(File dir, BiFunction<Git, String, @Nullable Integer> commitCountProvider, String... globFilters) {
         def git
         def parent = SystemReader.instance

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -170,6 +170,8 @@ class GradleUtils {
             // match isn't an attribute, we can call setMatch() twice since it just adds matches
             if (tagPrefix) match = new String[] { tagPrefix + "**" }
             if (globFilters) match = globFilters
+
+            return it
         }.call()
 
         var desc = rsplit(tag, '-', 2)

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -127,17 +127,17 @@ class GradleUtils {
 
     // I LOVE NOT BREAKING BINARY COMPAT!!!!!! :) :) :)
     static Map<String, String> gitInfoCheckSubproject(Project project, String filterFromSubproject) {
-        return gitInfo(findGitRoot(project).get().asFile, (git, tag) -> filterFromSubproject ? getSubprojectCommitCount(project, git, tag, filterFromSubproject) : null, filterFromSubproject, new String[0])
+        return gitInfo(findGitRoot(project).get().asFile, (git, tag) -> getSubprojectCommitCount(project, git, tag, filterFromSubproject), filterFromSubproject, new String[0])
     }
 
     // I LOVE NOT BREAKING BINARY COMPAT!!!!!! :) :) :)
     static Map<String, String> gitInfoCheckSubproject(Project project, String filterFromSubproject, String tagPrefixOverride) {
-        return gitInfo(findGitRoot(project).get().asFile, (git, tag) -> filterFromSubproject ? getSubprojectCommitCount(project, git, tag, filterFromSubproject) : null, tagPrefixOverride, new String[0])
+        return gitInfo(findGitRoot(project).get().asFile, (git, tag) -> getSubprojectCommitCount(project, git, tag, filterFromSubproject), tagPrefixOverride, new String[0])
     }
 
     // I LOVE NOT BREAKING BINARY COMPAT!!!!!! :) :) :)
     static Map<String, String> gitInfoCheckSubproject(Project project, String filterFromSubproject, String tagPrefixOverride, String globFilter) {
-        return gitInfo(findGitRoot(project).get().asFile, (git, tag) -> filterFromSubproject ? getSubprojectCommitCount(project, git, tag, filterFromSubproject) : null, tagPrefixOverride, new String[] { globFilter })
+        return gitInfo(findGitRoot(project).get().asFile, (git, tag) -> getSubprojectCommitCount(project, git, tag, filterFromSubproject), tagPrefixOverride, new String[] { globFilter })
     }
 
     static Map<String, String> gitInfo(Project project, String... globFilters) {
@@ -211,6 +211,9 @@ class GradleUtils {
         ret.commit = ObjectId.toString(head.objectId)
         ret.abbreviatedId = head.objectId.abbreviate(8).name()
 
+        // additional garbage
+        ret.tagPrefix = tagPrefix
+
         // Remove any lingering null values
         ret.removeAll {it.value === null }
 
@@ -219,6 +222,8 @@ class GradleUtils {
     }
 
     static @Nullable Integer getSubprojectCommitCount(Project project, Git git, String tag, String filter) {
+        if ((filter === null || filter.isEmpty()) && project.subprojects.isEmpty()) return null
+
 //        println "Getting subproject commit count! Tag: $tag, filter: $filter"
         var tags = getTagToCommitMap(git)
         var commitHash = tags.get(tag)

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -169,7 +169,7 @@ class GradleUtils {
 
             // match isn't an attribute, we can call setMatch() twice since it just adds matches
             if (tagPrefix) match = new String[] { tagPrefix + "**" }
-            match = globFilters ?: new String[0]
+            if (globFilters) match = globFilters
         }.call()
 
         var desc = rsplit(tag, '-', 2)

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -153,8 +153,8 @@ class GradleUtils {
     static Map<String, String> gitInfo(File dir, BiFunction<Git, String, @Nullable Integer> commitCountProvider, @Nullable String tagPrefix, String... globFilters) {
         println "Getting git info! Dir: $dir, tagPrefix: $tagPrefix, globFilters: [${String.join(', ', globFilters)}]"
 
-        def git
-        def parent = SystemReader.instance
+        var git
+        var parent = SystemReader.instance
         SystemReader.instance = new DisableSystemConfig(parent)
 
         try {
@@ -163,7 +163,7 @@ class GradleUtils {
             println 'ERROR: Failed to describe git info! Not in a git repository?'
             return DEFAULT_GIT_INFO
         }
-        def tag = git.describe().tap {
+        var tag = git.describe().tap {
             tags = true
             it.long = true
 
@@ -172,7 +172,7 @@ class GradleUtils {
             match = globFilters ?: new String[0]
         }.call()
 
-        def desc = rsplit(tag, '-', 2)
+        var desc = rsplit(tag, '-', 2)
         if (desc === null) {
             println "ERROR: Failed to describe git info! Incorrect filters? Tag prefix: ${tagPrefix}, glob filters: [${String.join(', ', globFilters)}]"
             return DEFAULT_GIT_INFO
@@ -207,17 +207,17 @@ class GradleUtils {
         if (filter === null || filter.isEmpty()) return null
 
         println "Getting subproject commit count! Tag: $tag, filter: $filter"
-        def tags = getTagToCommitMap(git)
-        def commitHash = tags.get(tag)
-        def commit = commitHash != null ? ObjectId.fromString(commitHash) : getFirstCommitInRepository(git).toObjectId()
+        var tags = getTagToCommitMap(git)
+        var commitHash = tags.get(tag)
+        var commit = commitHash != null ? ObjectId.fromString(commitHash) : getFirstCommitInRepository(git).toObjectId()
 
-        def start = getCommitFromId(git, commit)
-        def end = getHead(git)
+        var start = getCommitFromId(git, commit)
+        var end = getHead(git)
 
-        def log = git.log().add(end)
+        var log = git.log().add(end)
 
         // If our starting commit contains at least one parent (it is not the 'root' commit), exclude all of those parents
-        for (RevCommit parent : start.getParents()) {
+        for (var parent : start.getParents()) {
             log.not(parent)
         }
         // We do not exclude the starting commit itself, so the commit is present in the returned iterable

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
@@ -6,6 +6,7 @@ package net.minecraftforge.gradleutils
 
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Provider
 
 import javax.inject.Inject
@@ -14,6 +15,7 @@ import javax.inject.Inject
 class GradleUtilsExtension {
     private final Project project
     private final String defaultFilter
+    final DirectoryProperty gitRoot
     private Provider<Map<String, String>> gitInfo
 
     @Inject
@@ -21,6 +23,7 @@ class GradleUtilsExtension {
         this.project = project
 
         this.defaultFilter = GradleUtils.makeFilterFromSubproject(project)
+        this.gitRoot = project.objects.directoryProperty().convention(GradleUtils.findGitRoot(project))
         this.gitInfo = project.objects.mapProperty(String, String).convention(project.provider { GradleUtils.gitInfoCheckSubproject(project, this.defaultFilter) })
     }
 

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
@@ -37,9 +37,10 @@ class GradleUtilsExtension {
     }
 
     String getTagOffsetVersion(String tagPrefix) {
-        if (!tagPrefix.endsWith("-"))
-            tagPrefix += "-"
+        if (tagPrefix === null || tagPrefix.isEmpty())
+            return GradleUtils.getTagOffsetVersion(getGitInfo())
 
+        if (!tagPrefix.endsWith("-")) tagPrefix += "-"
         return this.getFilteredTagOffsetVersion(true, tagPrefix)
     }
 

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
@@ -24,7 +24,7 @@ class GradleUtilsExtension {
 
         this.gitRoot = project.objects.directoryProperty().convention(GradleUtils.findGitRoot(project))
         this.gitInfo = project.objects.mapProperty(String, String)
-                .convention(gitRoot.map((Directory dir) -> GradleUtils.gitInfo(dir.asFile)))
+                .convention(gitRoot.map((Directory dir) -> GradleUtils.gitInfo(project)))
     }
 
     /**
@@ -33,7 +33,14 @@ class GradleUtilsExtension {
      * @return a version in the form {@code $tag.$offset}, e.g. 1.0.5
      */
     String getTagOffsetVersion() {
-        return GradleUtils.getTagOffsetVersion(getGitInfo())
+        return this.getTagOffsetVersion(GradleUtils.makeFilterFromSubproject(project))
+    }
+
+    String getTagOffsetVersion(String tagPrefix) {
+        if (!tagPrefix.endsWith("-"))
+            tagPrefix += "-"
+
+        return this.getFilteredTagOffsetVersion(true, tagPrefix)
     }
 
     /**

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
@@ -22,7 +22,7 @@ class GradleUtilsExtension {
     GradleUtilsExtension(Project project) {
         this.project = project
 
-        this.gitRoot = project.objects.directoryProperty().convention(project.layout.projectDirectory)
+        this.gitRoot = project.objects.directoryProperty().convention(GradleUtils.findGitRoot(project))
         this.gitInfo = project.objects.mapProperty(String, String)
                 .convention(gitRoot.map((Directory dir) -> GradleUtils.gitInfo(dir.asFile)))
     }

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsPlugin.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsPlugin.groovy
@@ -15,6 +15,7 @@ class GradleUtilsPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.plugins.apply(ChangelogPlugin)
         project.extensions.create("gradleutils", GradleUtilsExtension, project)
+        GenerateActionsWorkflow.register(project)
         //Setup the teamcity project task.
         GradleUtils.setupCITasks(project)
     }

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogExtension.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogExtension.groovy
@@ -48,6 +48,13 @@ class ChangelogExtension {
         }
     }
 
+    void tagPrefix(String prefix) {
+        task = ChangelogUtils.setupChangelogTask(this.project)
+        task.configure {
+            tagPrefix = prefix
+        }
+    }
+
     void publish(MavenPublication publication) {
         ChangelogUtils.setupChangelogGenerationForPublishing(project, publication)
     }

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogPlugin.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogPlugin.groovy
@@ -5,9 +5,6 @@
 package net.minecraftforge.gradleutils.changelog
 
 import groovy.transform.CompileStatic
-import net.minecraftforge.gradleutils.GradleUtils
-import net.minecraftforge.gradleutils.GradleUtilsExtension
-import net.minecraftforge.gradleutils.changelog.ChangelogExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogUtils.groovy
@@ -7,16 +7,13 @@ package net.minecraftforge.gradleutils.changelog
 import groovy.transform.PackageScope
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.ListBranchCommand
-import org.eclipse.jgit.diff.DiffEntry
 import org.eclipse.jgit.errors.MissingObjectException
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.ObjectId
-import org.eclipse.jgit.lib.ObjectReader
 import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.revwalk.filter.RevFilter
-import org.eclipse.jgit.treewalk.CanonicalTreeParser
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -269,10 +266,10 @@ class ChangelogUtils {
      * @return The commit log.
      */
     private static Iterable<RevCommit> getCommitLogFromTo(final Git git, final RevCommit start, final RevCommit end, final String filter) {
-        def log = git.log().add(end)
+        var log = git.log().add(end)
 
         // If our starting commit contains at least one parent (it is not the 'root' commit), exclude all of those parents
-        for (RevCommit parent : start.getParents()) {
+        for (var parent : start.getParents()) {
             log.not(parent)
         }
         // We do not exclude the starting commit itself, so the commit is present in the returned iterable

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogUtils.groovy
@@ -44,6 +44,23 @@ class ChangelogUtils {
      * @param endCommitHash The commit hash of the commit to use as the end of the changelog.
      * @return A multiline changelog string.
      */
+    @Deprecated(forRemoval = true, since = "2.3")
+    static String generateChangelogFromTo(final Git git, final String repositoryUrl, final boolean justText, final RevCommit start, final RevCommit end) {
+        return generateChangelogFromTo(git, repositoryUrl, justText, start, end, null);
+    }
+
+    /**
+     * Generates a changelog string that can be written to a file from a given git directory and repository url.
+     * The changes will be generated from the given commit to the given commit.
+     *
+     * @param projectDirectory The directory from which to pull the git commit information.
+     * @param repositoryUrl The github url of the repository.
+     * @param justText Indicates if plain text ({@code true}) should be used, or changelog should be used ({@code false}).
+     * @param commitHash The commit hash of the commit to use as the beginning of the changelog.
+     * @param endCommitHash The commit hash of the commit to use as the end of the changelog.
+     * @param filter The filter to decide how to ignore certain commits.
+     * @return A multiline changelog string.
+     */
     static String generateChangelogFromTo(final Git git, final String repositoryUrl, final boolean justText, final RevCommit start, final RevCommit end, final String filter) {
         def endCommitHash = end.toObjectId().getName(); //Grab the commit hash of the end commit.
         def startCommitHash = start.toObjectId().getName(); //Grab the commit hash of the start commit.
@@ -248,6 +265,7 @@ class ChangelogUtils {
      * @param git The git workspace to get the commits from.
      * @param start The start commit (the oldest).
      * @param end The end commit (the youngest).
+     * @param filter The filter to decide how to ignore certain commits.
      * @return The commit log.
      */
     private static Iterable<RevCommit> getCommitLogFromTo(final Git git, final RevCommit start, final RevCommit end, final String filter) {

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/CopyChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/CopyChangelog.groovy
@@ -6,7 +6,6 @@ package net.minecraftforge.gradleutils.changelog
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFiles

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
@@ -67,9 +67,6 @@ abstract class GenerateChangelog extends DefaultTask {
     @TaskAction
     void exec() throws IOException {
         def filter = getFilter().getOrNull()
-        println "filter = $filter"
-        println "filter null? = ${filter == null}"
-        println "filter empty? = ${filter == null || filter.isEmpty()}"
 
         def tagPrefix = getTagPrefix().getOrElse(filter)
         if (!tagPrefix.endsWith("-")) tagPrefix += "-"

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
@@ -23,20 +23,10 @@ abstract class GenerateChangelog extends DefaultTask {
 
     GenerateChangelog() {
         //Setup defaults: Using merge-base based text changelog generation of the local project into build/changelog.txt
-        gitDirectory.convention findGitDirectory(this.project)
+        gitDirectory.convention GradleUtils.findGitDirectory(this.project)
         getBuildMarkdown().convention(false);
         filter.convention makeFilterFromSubproject(this.project)
         getOutputFile().convention(getProject().getLayout().getBuildDirectory().file("changelog.txt"));
-    }
-
-    private static Provider<Directory> findGitDirectory(Project project) {
-        return project.provider {
-            // first, try the current project dir. we might be a submodule
-            project.layout.projectDirectory.dir(".git")
-        }.orElse(project.provider {
-            // if that fails, try the root project dir
-            project.rootProject.layout.projectDirectory.dir(".git")
-        })
     }
 
     private static Provider<String> makeFilterFromSubproject(Project project) {
@@ -44,7 +34,10 @@ abstract class GenerateChangelog extends DefaultTask {
             def root = project.rootProject.projectDir
             def local = project.projectDir
 
-            local.absolutePath.substring(root.absolutePath.length())
+            def result = local.absolutePath.substring(root.absolutePath.length())
+            if (result.startsWith(File.separator))
+                result = result.substring(1)
+            return result
         }
     }
 

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
@@ -11,7 +11,6 @@ import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.util.SystemReader;
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property
@@ -19,8 +18,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.*
 
 abstract class GenerateChangelog extends DefaultTask {
-    private final Directory projectDir
-
     GenerateChangelog() {
         //Setup defaults: Using merge-base based text changelog generation of the local project into build/changelog.txt
         gitDirectory.convention GradleUtils.findGitDirectory(this.project)
@@ -52,6 +49,7 @@ abstract class GenerateChangelog extends DefaultTask {
     abstract Property<String> getFilter();
 
     @Input
+    @Optional
     abstract Property<String> getTagPrefix();
 
     @Input

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
@@ -51,6 +51,8 @@ abstract class GenerateChangelog extends DefaultTask {
     @Input
     abstract Property<String> getFilter();
 
+    abstract Property<String> getTagPrefix();
+
     @Input
     abstract Property<Boolean> getBuildMarkdown();
 
@@ -68,6 +70,9 @@ abstract class GenerateChangelog extends DefaultTask {
         println "filter = $filter"
         println "filter null? = ${filter == null}"
         println "filter empty? = ${filter == null || filter.isEmpty()}"
+
+        def tagPrefix = getTagPrefix().getOrElse(filter)
+        if (!tagPrefix.endsWith("-")) tagPrefix += "-"
 
         String changelog = ""
         def parent = SystemReader.instance
@@ -95,7 +100,7 @@ abstract class GenerateChangelog extends DefaultTask {
             }
 
             def head = ChangelogUtils.getHead(git)
-            changelog = ChangelogUtils.generateChangelogFromTo(git, url, !buildMarkdown.get(), from, head)
+            changelog = ChangelogUtils.generateChangelogFromTo(git, url, !buildMarkdown.get(), from, head, filter)
         } finally {
             SystemReader.instance = parent
         }

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
@@ -10,11 +10,9 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.util.SystemReader;
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.*
 
 abstract class GenerateChangelog extends DefaultTask {

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
@@ -53,9 +53,9 @@ abstract class GenerateChangelog extends DefaultTask {
 
     @TaskAction
     void exec() throws IOException {
-        def filter = getFilter().getOrNull()
+        var filter = getFilter().getOrNull()
 
-        def tagPrefix = getTagPrefix().getOrElse(filter)
+        var tagPrefix = getTagPrefix().getOrElse(filter)
         if (!tagPrefix.endsWith("-")) tagPrefix += "-"
 
         String changelog = ""

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
@@ -51,6 +51,7 @@ abstract class GenerateChangelog extends DefaultTask {
     @Input
     abstract Property<String> getFilter();
 
+    @Input
     abstract Property<String> getTagPrefix();
 
     @Input

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/GenerateChangelog.groovy
@@ -20,22 +20,10 @@ import org.gradle.api.tasks.*
 abstract class GenerateChangelog extends DefaultTask {
     GenerateChangelog() {
         //Setup defaults: Using merge-base based text changelog generation of the local project into build/changelog.txt
+        outputFile.convention project.layout.buildDirectory.file("changelog.txt")
         gitDirectory.convention GradleUtils.findGitDirectory(this.project)
-        getBuildMarkdown().convention(false);
-        filter.convention makeFilterFromSubproject(this.project)
-        getOutputFile().convention(getProject().getLayout().getBuildDirectory().file("changelog.txt"));
-    }
-
-    private static Provider<String> makeFilterFromSubproject(Project project) {
-        return project.provider {
-            def root = project.rootProject.projectDir
-            def local = project.projectDir
-
-            def result = local.absolutePath.substring(root.absolutePath.length())
-            if (result.startsWith(File.separator))
-                result = result.substring(1)
-            return result
-        }
+        filter.convention GradleUtils.makeFilterFromSubproject(this.project)
+        buildMarkdown.convention false
     }
 
     @OutputFile


### PR DESCRIPTION
Name entails. This is part of my push to use monorepos for projects that are small in scale, such as ForgeGradle 7 and our new toolchain utilities.

This effectively works by creating a filter from the subproject, if we are in one. If we are in a subproject, use the filter to ignore any commits that do not modify files in the subproject, and use the filter to only use tags that are prefixed with the filter (subproject name).

This tag filter can be changed, of course. If your subproject is `test-project` but you want to use tags that are prefixed with `test-`, you can state your version like this:

```gradle
version = gradleutils.getTagOffsetVersion('test')
```

In the same manner, changelogs have also recieved much of the same treatment, using a filter that is set to the subproject. Tag prefixed can be changed in the changelog config:

```gradle
changelog {
    tagPrefix = 'test'
```

All tag filters are assumed to be appended with `-`, but the way I've written it allows users to append it themselves. Thus, `tagPrefix = 'test-'` or `gradleutils.getTagOffsetVersion('test-')` will function as intended. If you would like me to remove this functionality, let me know.