### PR TITLE
2.5 - Cleanup and Git Version Plugin API change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,25 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     id 'java-gradle-plugin'
     id 'groovy'
     id 'idea'
+    id 'eclipse'
     id 'maven-publish'
     id 'net.minecraftforge.licenser' version '1.1.1'
-    id 'com.gradle.plugin-publish' version '1.2.1'
     id 'net.minecraftforge.gradleutils'
+    id 'com.gradle.plugin-publish' version '1.3.1'
     id 'com.gradleup.shadow' version '8.3.6'
 }
 
+final projectDisplayName = 'Forge Gradle Utilities'
+description = 'Small collection of utilities for standardizing MinecraftForge gradle scripts'
 group = 'net.minecraftforge'
-version = gitversion.version.tagOffset
+version = gitversion.tagOffset
+
 println "Version: $version"
 
 apply from: 'build_shared.gradle'
-
-tasks.withType(GroovyCompile).configureEach {
-    groovyOptions.optimizationOptions.indy = true
-}
 
 license {
     header = file('LICENSE-header.txt')
@@ -25,11 +27,11 @@ license {
     exclude '** /*.properties'
 }
 
-jar {
+tasks.named('jar', Jar) {
     archiveClassifier = 'thin'
 }
 
-tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+tasks.named('shadowJar', ShadowJar) {
     enableRelocation =  true
     archiveClassifier = null
     relocationPrefix = 'net.minecraftforge.gradleutils.shadow'
@@ -41,7 +43,7 @@ groovydoc.use = true
 // javadocJar is created after evaluation, so we need to configure it here
 afterEvaluate {
     tasks.named('javadocJar', Jar) {
-        dependsOn groovydoc
+        dependsOn tasks.named('groovydoc', Groovydoc)
         from groovydoc.destinationDir
     }
 }
@@ -51,13 +53,34 @@ changelog {
     publishAll = false
 }
 
+gradlePlugin {
+    website = gitversion.url
+    vcsUrl = "${gitversion.url}.git"
+    plugins {
+        gradleutils {
+            id = 'net.minecraftforge.gradleutils'
+            implementationClass = 'net.minecraftforge.gradleutils.GradleUtilsPlugin'
+            displayName = projectDisplayName
+            description = project.description
+            tags.set(['minecraftforge'])
+        }
+        changelog {
+            id = 'net.minecraftforge.changelog'
+            implementationClass = 'net.minecraftforge.gradleutils.changelog.ChangelogPlugin'
+            displayName = 'Git Changelog'
+            description = 'Creates a changelog text file based on git history using GitVersion'
+            tags.set(['git', 'changelog'])
+        }
+    }
+}
+
 publishing {
     publications.register('pluginMaven', MavenPublication) {
         changelog.publish(it)
         pom { pom ->
-            artifactId = 'gradleutils'
-            name = 'Gradle Utils'
-            description = 'Used by MinecraftForge projects as a util library for Gradle buildscripts'
+            artifactId = project.name
+            name = projectDisplayName
+            description = project.description
 
             gradleutils.pom.gitHubDetails = pom
 
@@ -65,10 +88,10 @@ publishing {
 
             // TODO [GradleUtils] Re-evaluate active developers in GU 3.0
             developers {
-                developer gradleutils.pom.Developers.LexManos
-                developer gradleutils.pom.Developers.SizableShrimp
-                developer gradleutils.pom.Developers.Paint_Ninja
-                developer gradleutils.pom.Developers.Jonathing
+                developer gradleutils.pom.developers.LexManos
+                developer gradleutils.pom.developers.SizableShrimp
+                developer gradleutils.pom.developers.Paint_Ninja
+                developer gradleutils.pom.developers.Jonathing
             }
         }
     }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,10 +4,13 @@ plugins {
 
 apply from: '../build_shared.gradle'
 
-sourceSets {
-    main {
-        groovy {
-            srcDirs = ['../src/main/groovy']
+sourceSets.main.groovy.srcDirs = ['../src/main/groovy']
+
+gradlePlugin {
+    plugins {
+        gradleutils {
+            id = 'net.minecraftforge.gradleutils'
+            implementationClass = 'net.minecraftforge.gradleutils.GradleUtilsPlugin'
         }
     }
 }

--- a/build_shared.gradle
+++ b/build_shared.gradle
@@ -1,8 +1,11 @@
-
 java {
     // GitVersion requires Java 17
     toolchain.languageVersion = JavaLanguageVersion.of(17)
     withSourcesJar()
+}
+
+tasks.withType(GroovyCompile).configureEach {
+    groovyOptions.optimizationOptions.indy = true
 }
 
 repositories {
@@ -27,25 +30,4 @@ dependencies {
 
     // TODO - Deprecated git utilities, remove in 3.0
     implementation libs.jgit
-}
-
-gradlePlugin {
-    website = 'https://github.com/MinecraftForge/GradleUtils'
-    vcsUrl = 'https://github.com/MinecraftForge/GradleUtils.git'
-    plugins {
-        gradleutils {
-            id = 'net.minecraftforge.gradleutils'
-            implementationClass = 'net.minecraftforge.gradleutils.GradleUtilsPlugin'
-            displayName = 'Forge Gradle Utilities'
-            description = 'Small collection of utilities for standardizing our gradle scripts'
-            tags.set(['minecraftforge'])
-        }
-        changelog {
-            id = 'net.minecraftforge.changelog'
-            implementationClass = 'net.minecraftforge.gradleutils.changelog.ChangelogPlugin'
-            displayName = 'Git Changelog'
-            description = 'Creates a changelog text file based on git history using GitVersion'
-            tags.set(['git', 'changelog'])
-        }
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.configuration-cache.problems=warn

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,6 @@ plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
 }
 
-rootProject.name = 'GradleUtils'
+rootProject.name = 'gradleutils'
 
 apply from: 'settings_shared.gradle'

--- a/src/main/groovy/net/minecraftforge/gradleutils/ConfigureTeamCity.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/ConfigureTeamCity.groovy
@@ -18,7 +18,7 @@ import javax.inject.Inject
 /**
  * This task prints the marker lines into the log which configure the pipeline.
  *
- * @deprecated Will be removed once Forge moves off of TeamCity
+ * @deprecated Will be removed once Forge moves off of TeamCity.
  */
 @CompileStatic
 @Deprecated(forRemoval = true)
@@ -33,26 +33,24 @@ abstract class ConfigureTeamCity extends DefaultTask {
         project.tasks.register(name, ConfigureTeamCity)
     }
 
-    @Inject
-    abstract ProviderFactory getProviders()
+    @Inject abstract ProviderFactory getProviders()
 
     ConfigureTeamCity() {
         this.description = 'Prints the marker lines into the log which configure the pipeline. [deprecated]'
         this.onlyIf('Only runs on TeamCity, so the TEAMCITY_VERSION environment variable must be set.') { GradleUtils.hasEnvVar('TEAMCITY_VERSION', this.providers).get() }
 
-        this.version.convention this.providers.provider { this.project.version?.toString() }
+        this.buildNumber.convention this.providers.provider { this.project.version?.toString() }
     }
 
-    /** The version string to print, usually the {@linkplain Project#getVersion() project version}. */
-    @Input
-    abstract Property<String> getVersion()
+    /** The build number to print, usually the project version. */
+    abstract @Input Property<String> getBuildNumber()
 
     @TaskAction
     void exec() {
         this.logger.warn 'WARNING: Usage of TeamCity is deprecated within Minecraft Forge Minecraft Forge has been gradually moving off of TeamCity and into GitHub Actions. When the migration is fully complete, this task along with its automatic setup will be removed.'
 
         this.logger.lifecycle 'Setting project variables and parameters.'
-        println "##teamcity[buildNumber '${this.version.get()}']"
-        println "##teamcity[setParameter name='env.PUBLISHED_JAVA_ARTIFACT_VERSION' value='${this.version.get()}']"
+        println "##teamcity[buildNumber '${this.buildNumber.get()}']"
+        println "##teamcity[setParameter name='env.PUBLISHED_JAVA_ARTIFACT_VERSION' value='${this.buildNumber.get()}']"
     }
 }

--- a/src/main/groovy/net/minecraftforge/gradleutils/GenerateActionsWorkflow.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GenerateActionsWorkflow.groovy
@@ -5,6 +5,7 @@
 package net.minecraftforge.gradleutils
 
 import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 import net.minecraftforge.gradleutils.gitversion.GitVersionExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -24,23 +25,17 @@ import javax.inject.Inject
 
 /**
  * This task generates the GitHub Actions workflow file for the project, respecting declared subprojects in Git Version.
- * <p>
- * This can be very useful when creating new projects or subprojects.
+ * <p>This can be very useful when creating new projects or subprojects.</p>
  */
 @CompileStatic
 abstract class GenerateActionsWorkflow extends DefaultTask {
     public static final String NAME = 'generateActionsWorkflow'
 
-    static TaskProvider<GenerateActionsWorkflow> register(Project project) {
-        register(project, NAME)
+    @PackageScope static TaskProvider<GenerateActionsWorkflow> register(Project project) {
+        project.tasks.register(NAME, GenerateActionsWorkflow)
     }
 
-    static TaskProvider<GenerateActionsWorkflow> register(Project project, String name) {
-        project.tasks.register(name, GenerateActionsWorkflow)
-    }
-
-    @Inject
-    abstract ProviderFactory getProviders()
+    @Inject abstract ProviderFactory getProviders()
 
     GenerateActionsWorkflow() {
         this.description = 'Generates the GitHub Actions workflow file for the project, respecting declared subprojects in Git Version.'
@@ -48,36 +43,21 @@ abstract class GenerateActionsWorkflow extends DefaultTask {
         this.outputFile.convention this.project.rootProject.layout.projectDirectory.file(this.providers.provider { "build_${this.project.name}.yaml" })
 
         this.projectName.convention this.providers.provider { this.project.name }
-        this.branch.convention this.providers.provider { this.project.extensions.getByType(GitVersionExtension).version.info.branch }
-        this.localPath.convention this.providers.provider { this.project.extensions.getByType(GitVersionExtension).version.projectPath }
-        this.paths.convention this.providers.provider { this.project.extensions.getByType(GitVersionExtension).version.subprojectPaths.collect { "!${it}/**".toString() } }
+        this.branch.convention this.providers.provider { this.project.extensions.getByType(GitVersionExtension).info.branch }
+        this.localPath.convention this.project.extensions.getByType(GitVersionExtension).projectPath
+        this.paths.convention this.providers.provider { this.project.extensions.getByType(GitVersionExtension).subprojectPaths.get().collect { "!${it}/**".toString() } }
         this.gradleJavaVersion.convention 21
         this.sharedActionsBranch.convention 'v0'
     }
 
-    @OutputFile
-    abstract RegularFileProperty getOutputFile()
+    abstract @OutputFile RegularFileProperty getOutputFile()
 
-    @Input
-    abstract Property<String> getProjectName()
-
-    @Input
-    @Optional
-    abstract Property<String> getBranch()
-
-    @Input
-    @Optional
-    abstract Property<String> getLocalPath()
-
-    @Input
-    @Optional
-    abstract ListProperty<String> getPaths()
-
-    @Input
-    abstract Property<Integer> getGradleJavaVersion()
-
-    @Input
-    abstract Property<String> getSharedActionsBranch()
+    abstract @Input Property<String> getProjectName()
+    abstract @Input @Optional Property<String> getBranch()
+    abstract @Input @Optional Property<String> getLocalPath()
+    abstract @Input @Optional ListProperty<String> getPaths()
+    abstract @Input Property<Integer> getGradleJavaVersion()
+    abstract @Input Property<String> getSharedActionsBranch()
 
     @TaskAction
     void exec() throws IOException {

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtils.groovy
@@ -51,12 +51,14 @@ class GradleUtils {
     //@formatter:off
     @CompileDynamic
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     private static void initDynamic() { String.metaClass.rsplit = GradleUtils.&rsplit }
     static { initDynamic() }
     //@formatter:on
 
     private static boolean rsplitDeprecationLogged
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static @Nullable List<String> rsplit(@Nullable String input, String del, int limit = -1) {
         if (!rsplitDeprecationLogged) {
             println 'WARNING: Usage of GradleUtils.rsplit is DEPRECATED and will be removed in GradleUtils 3.0!'
@@ -67,6 +69,7 @@ class GradleUtils {
     }
 
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     private static @Nullable List<String> rsplitInternal(@Nullable String input, String del, int limit = -1) {
         if (input === null) return null
         List<String> lst = []
@@ -84,6 +87,7 @@ class GradleUtils {
     /** @deprecated Use {@link GitVersion#disableSystemConfig() */
     @Deprecated(forRemoval = true, since = '2.4')
     @CompileStatic
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static class DisableSystemConfig extends SystemReader.Delegate {
         final SystemReader parent
 
@@ -107,6 +111,7 @@ class GradleUtils {
     private static boolean gitInfoDeprecationLogged
     /** @deprecated Use {@link GitVersion#getInfo()} via {@link net.minecraftforge.gradleutils.gitversion.GitVersionExtension#getVersion() GitVersionExtension.getVersion()} */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static Map<String, String> gitInfo(File dir, String... globFilters) {
         if (!gitInfoDeprecationLogged) {
             println 'WARNING: Usage of GradleUtils.gitInfo(File, String...) is DEPRECATED and will be removed in GradleUtils 3.0! Consider using GitVersion.disableSystemConfig() instead.'
@@ -213,7 +218,7 @@ class GradleUtils {
      *
      * @return The action
      */
-    static Action<? super MavenArtifactRepository> getForgeMaven() {
+    static Closure getForgeMaven() {
         { MavenArtifactRepository repo ->
             repo.name = 'MinecraftForge'
             repo.url = 'https://maven.minecraftforge.net/'
@@ -227,7 +232,7 @@ class GradleUtils {
      *
      * @return The action
      */
-    static Action<? super MavenArtifactRepository> getForgeReleaseMaven() {
+    static Closure getForgeReleaseMaven() {
         { MavenArtifactRepository repo ->
             repo.name = 'MinecraftForge releases'
             repo.url = 'https://maven.minecraftforge.net/releases'
@@ -241,7 +246,7 @@ class GradleUtils {
      *
      * @return The action
      */
-    static Action<? super MavenArtifactRepository> getForgeSnapshotMaven() {
+    static Closure getForgeSnapshotMaven() {
         { MavenArtifactRepository repo ->
             repo.name = 'MinecraftForge snapshots'
             repo.url = 'https://maven.minecraftforge.net/snapshots'
@@ -255,7 +260,7 @@ class GradleUtils {
      *
      * @return The action
      */
-    static Action<? super MavenArtifactRepository> getMinecraftLibsMaven() {
+    static Closure getMinecraftLibsMaven() {
         { MavenArtifactRepository repo ->
             repo.name = 'Minecraft libraries'
             repo.url = 'https://libraries.minecraft.net/'
@@ -270,12 +275,14 @@ class GradleUtils {
      * @deprecated Use {@link GitVersion#getTagOffset()} instead
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String getTagOffsetVersion(Map<String, String> info) {
         "${info.tag}.${info.offset}"
     }
 
     /** @deprecated Filters can no longer be defined at configuration. Use the Git Version config. */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String getFilteredTagOffsetVersion(Map<String, String> info, boolean prefix = false, String filter) {
         getTagOffsetVersion(info)
     }
@@ -290,6 +297,7 @@ class GradleUtils {
      * @deprecated Use {@link GitVersion#getTagOffsetBranch(String ...)} via {@link net.minecraftforge.gradleutils.gitversion.GitVersionExtension#getVersion() GitVersionExtension.getVersion()}
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String getTagOffsetBranchVersion(Map<String, String> info, String... allowedBranches) {
         if (!allowedBranches || allowedBranches.length === 0)
             allowedBranches = [null, 'master', 'main', 'HEAD']
@@ -303,6 +311,7 @@ class GradleUtils {
 
     /** @deprecated Filters can no longer be defined at configuration. Use the Git Version config. */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String getFilteredTagOffsetBranchVersion(Map<String, String> info, boolean prefix = false, String filter, String... allowedBranches) {
         getTagOffsetBranchVersion(info, allowedBranches)
     }
@@ -318,6 +327,7 @@ class GradleUtils {
      * @deprecated Use {@link GitVersion#getMCTagOffsetBranch(String, String ...)} instead
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String getMCTagOffsetBranchVersion(Map<String, String> info, String mcVersion, String... allowedBranches) {
         if (!allowedBranches || allowedBranches.length === 0)
             allowedBranches = [null, 'master', 'main', 'HEAD', mcVersion, mcVersion + '.0', mcVersion + '.x', rsplitInternal(mcVersion, '.', 1)[0] + '.x']
@@ -327,18 +337,21 @@ class GradleUtils {
 
     /** @deprecated Filters for GitVersion should be set early, using one of the methods in {@link GradleUtilsExtension} */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String getFilteredMCTagOffsetBranchVersion(Map<String, String> info, boolean prefix = false, String filter, String mcVersion, String... allowedBranches) {
         getMCTagOffsetBranchVersion(info, mcVersion, allowedBranches)
     }
 
     /** @see net.minecraftforge.gitver.internal.GitUtils#buildProjectUrl(String) GitUtils.buildProjectUrl(String) */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String buildProjectUrl(String project) {
         buildProjectUrl("MinecraftForge", project);
     }
 
     /** @see net.minecraftforge.gitver.internal.GitUtils#buildProjectUrl(String, String) GitUtils.buildProjectUrl(String, String) */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String buildProjectUrl(String organization, String project) {
         buildProjectUrlLogDeprecation()
         "https://github.com/${organization}/${project}"
@@ -352,6 +365,7 @@ class GradleUtils {
      * @deprecated Replaced by GitVersion, use {@link GitVersion.Info#getUrl()} via {@link net.minecraftforge.gradleutils.gitversion.GitVersionExtension#getVersion() GitVersionExtension.getVersion()}
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     static String buildProjectUrl(Git git) {
         buildProjectUrlLogDeprecation()
 
@@ -397,9 +411,10 @@ class GradleUtils {
 
     private static boolean buildProjectUrlDeprecationLogged
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     private static void buildProjectUrlLogDeprecation() {
         if (!buildProjectUrlDeprecationLogged) {
-            println 'WARNING: Usage of GradleUtils.buildProjectUrl is DEPRECATED and will be removed in GradleUtils 3.0! Use gitversion.version.info.url instead.'
+            println 'WARNING: Usage of GradleUtils.buildProjectUrl is DEPRECATED and will be removed in GradleUtils 3.0! Use gitversion.url instead.'
             buildProjectUrlDeprecationLogged = true
         }
     }

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsExtension.groovy
@@ -12,6 +12,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.annotations.ApiStatus
 
 import javax.inject.Inject
 
@@ -24,8 +25,8 @@ class GradleUtilsExtension {
     public static final String NAME = 'gradleutils'
 
     private final Project project
-    private final ProviderFactory providers
     private final ObjectFactory objects
+    private final ProviderFactory providers
 
     private final GitVersionExtension gitversion
 
@@ -34,32 +35,36 @@ class GradleUtilsExtension {
 
     /** @deprecated Use {@link net.minecraftforge.gitver.api.GitVersion#getRoot() GitVersion.getRoot()} via {@link GitVersionExtension#getVersion()} instead. */
     @Deprecated(forRemoval = true, since = '2.4') @Lazy DirectoryProperty gitRoot = {
-        this.project.logger.warn "WARNING: This project is still using 'gradleutils.gitRoot'. It has been deprecated and will be removed in GradleUtils 3.0. Consider using 'gitversion.version.root' instead."
+        this.project.logger.warn "WARNING: This project is still using 'gradleutils.gitRoot'. It has been deprecated and will be removed in GradleUtils 3.0. Consider using 'gitversion.rootDir' instead."
 
-        objects.directoryProperty().fileProvider providers.provider { this.gitversion.version.root }
+        this.gitversion.rootDir
     }()
     /** @deprecated Use {@link net.minecraftforge.gitver.api.GitVersion#getInfo() GitVersion.getInfo()} via {@link GitVersionExtension#getVersion()} instead. */
     @Deprecated(forRemoval = true, since = '2.4') @Lazy Map<String, String> gitInfo = {
-        this.project.logger.warn "WARNING: This project is still using 'gradleutils.gitInfo'. It has been deprecated and will be removed in GradleUtils 3.0. Consider using 'gitversion.version.info' instead."
+        this.project.logger.warn "WARNING: This project is still using 'gradleutils.gitInfo'. It has been deprecated and will be removed in GradleUtils 3.0. Consider using 'gitversion.info' instead."
 
-        var version = this.project.extensions.getByType(GitVersionExtension).version
+        var gitversion = this.project.extensions.getByType(GitVersionExtension)
+        var info = gitversion.info
         [
-            dir          : version.gitDir.absolutePath,
-            tag          : version.info.tag,
-            offset       : version.info.offset,
-            hash         : version.info.hash,
-            branch       : version.info.branch,
-            commit       : version.info.commit,
-            abbreviatedId: version.info.abbreviatedId,
-            url          : version.info.url
+            dir          : gitversion.gitDir.get().asFile.absolutePath,
+            tag          : info.tag,
+            offset       : info.offset,
+            hash         : info.hash,
+            branch       : info.branch,
+            commit       : info.commit,
+            abbreviatedId: info.abbreviatedId,
+            url          : gitversion.url
         ].tap { it.removeAll { it.value == null } }
     }()
 
+    /** @deprecated This constructor will be made package-private in GradleUtils 3.0 */
     @Inject
-    GradleUtilsExtension(Project project, ProviderFactory providers, ObjectFactory objects) {
+    @Deprecated(forRemoval = true)
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
+    GradleUtilsExtension(Project project, ObjectFactory objects, ProviderFactory providers) {
         this.project = project
-        this.providers = providers
         this.objects = objects
+        this.providers = providers
 
         // Git Version
         this.gitversion = project.extensions.getByType(GitVersionExtension)
@@ -79,15 +84,16 @@ class GradleUtilsExtension {
      *     version = gradleutils.tagOffsetVersion
      *
      *     // After:
-     *     version = gitversion.version.tagOffset
+     *     version = gitversion.tagOffset
      * </code></pre>
      *
      * @deprecated Use {@link net.minecraftforge.gitver.api.GitVersion#getTagOffset() GitVersion.tagOffset} instead.
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     String getTagOffsetVersion() {
         this.logDeprecation('tagOffsetVersion', 'tagOffsetVersion')
-        this.project.extensions.getByType(GitVersionExtension).version.tagOffset
+        this.project.extensions.getByType(GitVersionExtension).tagOffset
     }
 
     /**
@@ -97,13 +103,14 @@ class GradleUtilsExtension {
      *     version = gradleutils.tagOffsetVersion
      *
      *     // After:
-     *     version = gitversion.version.tagOffset
+     *     version = gitversion.tagOffset
      * </code></pre>
      * <strong>You must declare your filters in the Git Version config file!</strong>.
      *
      * @deprecated Use {@link net.minecraftforge.gitver.api.GitVersion#getTagOffset() GitVersion.tagOffset} instead.
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     String getFilteredTagOffsetVersion(boolean prefix = false, String filter) {
         this.updateInfo(prefix, filter)
         this.tagOffsetVersion
@@ -116,16 +123,17 @@ class GradleUtilsExtension {
      *     version = gradleutils.getTagOffsetBranchVersion()
      *
      *     // After:
-     *     version = gitversion.version.tagOffsetBranch
+     *     version = gitversion.tagOffsetBranch
      * </code></pre>
      *
      * @deprecated Use {@link net.minecraftforge.gitver.api.GitVersion#getTagOffsetBranch(String ...) GitVersion.getTagOffsetBranch(String...)} instead.
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     String getTagOffsetBranchVersion(String... allowedBranches) {
         this.logDeprecation('tagOffsetBranchVersion', 'getTagOffsetBranchVersion(String...)')
-        var version = this.project.extensions.getByType(GitVersionExtension).version
-        allowedBranches ? version.getTagOffsetBranch(allowedBranches) : version.tagOffsetBranch
+        var gitversion = this.project.extensions.getByType(GitVersionExtension)
+        allowedBranches ? gitversion.getTagOffsetBranch(allowedBranches) : gitversion.tagOffsetBranch
     }
 
     /**
@@ -135,7 +143,7 @@ class GradleUtilsExtension {
      *     version = gradleutils.tagOffsetBranchVersion
      *
      *     // After:
-     *     version = gitversion.version.tagOffsetBranch
+     *     version = gitversion.tagOffsetBranch
      * </code></pre>
      * <p>
      * <strong>You must declare your filters in the Git Version config file!</strong>.
@@ -143,6 +151,7 @@ class GradleUtilsExtension {
      * @deprecated Use {@link net.minecraftforge.gitver.api.GitVersion#getTagOffset() GitVersion.tagOffset} instead.
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     String getFilteredTagOffsetBranchVersion(boolean prefix = false, String filter, String... allowedBranches) {
         this.updateInfo(prefix, filter)
         this.getTagOffsetBranchVersion(allowedBranches)
@@ -155,16 +164,17 @@ class GradleUtilsExtension {
      *     version = gradleutils.getMCTagOffsetBranchVersion('1.21.4')
      *
      *     // After:
-     *     version = gitversion.version.getMCTagOffsetBranch('1.21.4')
+     *     version = gitversion.getMCTagOffsetBranch('1.21.4')
      * </code></pre>
      *
      * @deprecated Use {@link net.minecraftforge.gitver.api.GitVersion#getMCTagOffsetBranch(String, String ...) GitVersion.getMCTagOffsetBranch(String, String...)} instead.
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     String getMCTagOffsetBranchVersion(String mcVersion, String... allowedBranches) {
         this.logDeprecation('MCTagOffsetBranchVersion', 'getMCTagOffsetBranchVersion(String, String...)')
-        var version = this.project.extensions.getByType(GitVersionExtension).version
-        allowedBranches ? version.getMCTagOffsetBranch(mcVersion, allowedBranches) : version.getMCTagOffsetBranch(mcVersion)
+        var gitVersion = this.project.extensions.getByType(GitVersionExtension)
+        allowedBranches ? gitVersion.getMCTagOffsetBranch(mcVersion, allowedBranches) : gitVersion.getMCTagOffsetBranch(mcVersion)
     }
 
     /**
@@ -174,7 +184,7 @@ class GradleUtilsExtension {
      *     version = gradleutils.getMCTagOffsetBranchVersion('1.21.4')
      *
      *     // After:
-     *     version = gitversion.version.getMCTagOffsetBranch('1.21.4')
+     *     version = gitversion.getMCTagOffsetBranch('1.21.4')
      * </code></pre>
      * <p>
      * <strong>You must declare your filters in the Git Version config file!</strong>.
@@ -182,21 +192,23 @@ class GradleUtilsExtension {
      * @deprecated Use {@link net.minecraftforge.gitver.api.GitVersion#getMCTagOffsetBranch(String, String ...) GitVersion.getMCTagOffsetBranch(String, String...)} instead.
      */
     @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     String getFilteredMCTagOffsetBranchVersion(boolean prefix = false, String filter, String mcVersion, String... allowedBranches) {
         this.updateInfo(prefix, filter)
         this.getMCTagOffsetBranchVersion(mcVersion, allowedBranches)
     }
 
-    @Deprecated(since = '2.4')
+    @Deprecated(forRemoval = true, since = '2.4')
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
     private void updateInfo(boolean prefix, String filter) {
-        this.project.extensions.getByType(GitVersionExtension).version.tap {
+        this.gitversion.versionInternal.tap {
             if (prefix) it.tagPrefix = filter
             else it.filters = new String[] {filter}
         }
     }
 
     private void logDeprecation(String name, String fullName) {
-        this.project.logger.warn "WARNING: This project is still using 'gradleutils.$name'. It has been deprecated and will be removed in GradleUtils 3.0. Consider using 'gitversion.version.$fullName' instead."
+        this.project.logger.warn "WARNING: This project is still using 'gradleutils.$name'. It has been deprecated and will be removed in GradleUtils 3.0. Consider using 'gitversion.$fullName' instead."
     }
 
     /** @see GradleUtils#getPublishingForgeMaven(Project, File) */
@@ -205,22 +217,22 @@ class GradleUtilsExtension {
     }
 
     /** @see GradleUtils#getForgeMaven() */
-    static Action<? super MavenArtifactRepository> getForgeMaven() {
+    static Closure getForgeMaven() {
         GradleUtils.forgeMaven
     }
 
     /** @see GradleUtils#getForgeReleaseMaven() */
-    static Action<? super MavenArtifactRepository> getForgeReleaseMaven() {
+    static Closure getForgeReleaseMaven() {
         GradleUtils.forgeReleaseMaven
     }
 
     /** @see GradleUtils#getForgeSnapshotMaven() */
-    static Action<? super MavenArtifactRepository> getForgeSnapshotMaven() {
+    static Closure getForgeSnapshotMaven() {
         GradleUtils.forgeSnapshotMaven
     }
 
     /** @see GradleUtils#getMinecraftLibsMaven() */
-    static Action<? super MavenArtifactRepository> getMinecraftLibsMaven() {
+    static Closure getMinecraftLibsMaven() {
         GradleUtils.minecraftLibsMaven
     }
 }

--- a/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsPlugin.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/GradleUtilsPlugin.groovy
@@ -17,16 +17,16 @@ import javax.inject.Inject
 /** The entry point for the Gradle Utils plugin. Exists to create the {@linkplain GradleUtilsExtension extension}. */
 @CompileStatic
 abstract class GradleUtilsPlugin implements Plugin<Project> {
-    @Inject
-    abstract ProviderFactory getProviders()
-
-    @Inject
-    abstract ObjectFactory getObjects()
+    /** @see <a href="https://docs.gradle.org/current/userguide/service_injection.html#objectfactory">ObjectFactory Service Injection</a> */
+    @Inject abstract ObjectFactory getObjects()
+    /** @see <a href="https://docs.gradle.org/current/userguide/service_injection.html#providerfactory">ProviderFactory Service Injection</a> */
+    @Inject abstract ProviderFactory getProviders()
 
     @Override
     void apply(Project project) {
         project.plugins.apply(GitVersionPlugin)
         project.plugins.apply(ChangelogPlugin)
-        project.extensions.create(GradleUtilsExtension.NAME, GradleUtilsExtension, project, this.providers, this.objects)
+        // TODO [GradleUtils][3.0] Use direct constructor
+        project.extensions.create(GradleUtilsExtension.NAME, GradleUtilsExtension, project, this.objects, this.providers)
     }
 }

--- a/src/main/groovy/net/minecraftforge/gradleutils/PomUtils.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/PomUtils.groovy
@@ -9,66 +9,68 @@ import groovy.transform.PackageScope
 import net.minecraftforge.gradleutils.gitversion.GitVersionExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.logging.Logger
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPomDeveloper
 import org.gradle.api.publish.maven.MavenPomLicense
 import org.gradle.api.publish.maven.MavenPublication
+import org.jetbrains.annotations.ApiStatus
 
-/** Utilities for making configuring a {@link MavenPom} more ergonomic. */
+/**
+ * Utilities for making configuring a {@code MavenPom} more ergonomic.
+ *
+ * @see <a href="https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.publish.maven/-maven-pom/index.html?query=interface%20MavenPom">MavenPom</a>
+ */
 @CompileStatic
 @SuppressWarnings('unused')
 final class PomUtils {
     private final Project project
-    private final Logger logger
     private final ProviderFactory providers
 
     private final GitVersionExtension gitversion
 
     @PackageScope PomUtils(Project project, ProviderFactory providers, GitVersionExtension gitversion) {
         this.project = project
-        this.logger = project.logger
         this.providers = providers
         this.gitversion = gitversion
     }
 
+    /** Allows accessing licenses from buildscripts using {@code gradleutils.pom.licenses}. */
+    public static final Licenses licenses = new Licenses()
     @CompileStatic
     static final class Licenses {
-        public static final Closure Apache2_0 = { MavenPomLicense license ->
-            license.name.set('Apache License, Version 2.0')
-            license.url.set('https://www.apache.org/licenses/LICENSE-2.0.txt')
-        }
+        public static final Closure Apache2_0 = makeLicense('Apache-2.0', 'https://www.apache.org/licenses/LICENSE-2.0')
+        public static final Closure LGPLv2_1 = makeLicense('LGPL-2.1-only', 'https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html')
+        public static final Closure LGPLv3 = makeLicense('LGPL-3.0-only', 'https://www.gnu.org/licenses/lgpl-3.0-standalone.html')
+        public static final Closure MIT = makeLicense('MIT', 'https://opensource.org/license/mit/')
 
-        public static final Closure LGPLv2_1 = { MavenPomLicense license ->
-            license.name.set('LGPLv2.1')
-            license.url.set('https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt')
-        }
-
-        public static final Closure LGPLv3 = { MavenPomLicense license ->
-            license.name.set('LGPLv3')
-            license.url.set('https://www.gnu.org/licenses/lgpl-3.0.txt')
-        }
-
-        public static final Closure MIT = { MavenPomLicense license ->
-            license.name.set('MIT')
-            license.url.set('https://opensource.org/license/mit/')
+        private static Closure makeLicense(String name, String url) {
+            return { MavenPomLicense license ->
+                license.name.set name
+                license.url.set url
+                license.distribution.set 'repo'
+            }
         }
 
         private Licenses() {}
     }
 
-    /** Allows accessing licenses from buildscripts using {@code gradleutils.pom.licenses}. */
-    public static final Licenses licenses = new Licenses()
-
     /** Common developers in the Minecraft Forge organization. */
-    public static final Map<String, Action<? super MavenPomDeveloper>> Developers = [
+    public static final Map<String, Action<? super MavenPomDeveloper>> developers = [
         LexManos     : makeDev('LexManos', 'Lex Manos'),
         Paint_Ninja  : makeDev('Paint_Ninja'),
         SizableShrimp: makeDev('SizableShrimp'),
         cpw          : makeDev('cpw'),
         Jonathing    : makeDev('Jonathing', 'me@jonathing.me', 'https://jonathing.me', 'America/New_York') // i'm overkill
     ].withDefault(this.&makeDev) as Map<String, Action<? super MavenPomDeveloper>>
+
+    /**
+     * @deprecated Casing changed.
+     * @see #developers
+     */
+    @Deprecated(forRemoval = true)
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
+    public static final Map<String, Action<? super MavenPomDeveloper>> Developers = developers
 
     private static Action<? super MavenPomDeveloper> makeDev(String id, String name = id) {
         return { MavenPomDeveloper developer ->
@@ -87,11 +89,8 @@ final class PomUtils {
         }
     }
 
-    void promote(MavenPublication publication) {
-        PromoteArtifact.register(this.project, publication)
-    }
-
-    void promote(MavenPublication publication, String promotionType) {
+    @SuppressWarnings('GrDeprecatedAPIUsage')
+    void promote(MavenPublication publication, String promotionType = 'latest') {
         PromoteArtifact.Type type
         try {
             type = PromoteArtifact.Type.valueOf(promotionType.toUpperCase())
@@ -99,9 +98,7 @@ final class PomUtils {
             throw new IllegalArgumentException("Invalid promotion type: $promotionType. Known types: ${PromoteArtifact.Type.values()*.toString()}", e)
         }
 
-        PromoteArtifact.register(this.project, publication).configure { task ->
-            task.promotionType.set type
-        }
+        PromoteArtifact.register(this.project, publication, type)
     }
 
     /**
@@ -140,18 +137,18 @@ final class PomUtils {
 
         var inCI = GradleUtils.hasEnvVar('GITHUB_ACTIONS', this.providers).get().booleanValue()
 
-        var remoteUrl = stripProtocol(this.gitversion.version.info.url)
+        var remoteUrl = stripProtocol(this.gitversion.url)
         var url = remoteUrl
         if (organization && repo) {
             url = "github.com/${organization}/${repo}".toString()
 
             if (url && url == remoteUrl) {
-                this.logger.warn "WARNING: The repository name was specified in the 'setGitHubDetails' method, but it was already present in the Git remote URL. This is redundant and may cause issues if the remote repository URL changes in the future."
+                this.project.logger.warn "WARNING: The repository name was specified in the 'setGitHubDetails' method, but it was already present in the Git remote URL. This is redundant and may cause issues if the remote repository URL changes in the future."
             }
         }
 
         if (!url) {
-            this.logger.warn 'WARNING: The GitHub URL for this repo could not be automatically determined by Git Version. This is likely due to the repository not having any remotes, not having one set, or some other issue with Git Version.'
+            this.project.logger.warn 'WARNING: The GitHub URL for this repo could not be automatically determined by Git Version. This is likely due to the repository not having any remotes, not having one set, or some other issue with Git Version.'
             if (inCI)
                 throw new IllegalStateException('GitHub URL could not be determined, which is required in CI')
 
@@ -159,11 +156,11 @@ final class PomUtils {
         }
 
         if (!url.contains('github.com')) {
-            this.logger.warn "WARNING: The repository URL found or created in 'setGitHubDetails' does not include 'github.com' This is problematic since all Minecraft Forge projects are hosted on GitHub. Found url: $url"
+            this.project.logger.warn "WARNING: The repository URL found or created in 'setGitHubDetails' does not include 'github.com' This is problematic since all Minecraft Forge projects are hosted on GitHub. Found url: $url"
         }
 
         if (!url.contains('github.com/MinecraftForge')) {
-            this.logger.warn "WARNING: The repository URL found or created in 'setGitHubDetails' does not include 'github.com/MinecraftForge' This is problematic if you are attempting to publish this project, especially from GitHub Actions. Found url: $url"
+            this.project.logger.warn "WARNING: The repository URL found or created in 'setGitHubDetails' does not include 'github.com/MinecraftForge' This is problematic if you are attempting to publish this project, especially from GitHub Actions. Found url: $url"
         }
 
         var fullURL = "https://${url}".toString()

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogPlugin.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/ChangelogPlugin.groovy
@@ -13,6 +13,7 @@ import org.gradle.api.Project
 abstract class ChangelogPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.extensions.create(ChangelogExtension.NAME, ChangelogExtension, project)
+        // TODO [GradleUtils][3.0][Changelog] Use direct constructor
+        project.extensions.create ChangelogExtension.NAME, ChangelogExtension, project
     }
 }

--- a/src/main/groovy/net/minecraftforge/gradleutils/changelog/CopyChangelog.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/changelog/CopyChangelog.groovy
@@ -21,27 +21,18 @@ import javax.inject.Inject
 abstract class CopyChangelog extends DefaultTask {
     public static final String NAME = 'copyChangelog'
 
-    @Inject
-    abstract ProjectLayout getLayout()
+    @Inject abstract ProjectLayout getLayout()
 
     CopyChangelog() {
-        this.description = 'Copies a changelog file to this project\'s build directory.'
+        this.description = "Copies a changelog file to this project's build directory."
 
         this.outputFile.convention this.layout.buildDirectory.file('changelog.txt')
     }
 
     /** The output file for the copied changelog. */
-    @OutputFile
-    abstract RegularFileProperty getOutputFile()
-
-    /**
-     * The configuration (or file collection) containing the changelog to copy. It must be a
-     * {@link FileCollection#getSingleFile() single file}.
-     *
-     * @see ChangelogUtils#findChangelogTask(org.gradle.api.Project)
-     */
-    @InputFiles
-    abstract Property<FileCollection> getConfiguration()
+    abstract @OutputFile RegularFileProperty getOutputFile()
+    /** The configuration (or file collection) containing the changelog to copy. It must be a single file. */
+    abstract @InputFiles Property<FileCollection> getConfiguration()
 
     @TaskAction
     void exec() {

--- a/src/main/groovy/net/minecraftforge/gradleutils/gitversion/GitVersionExtension.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/gitversion/GitVersionExtension.groovy
@@ -5,33 +5,62 @@
 package net.minecraftforge.gradleutils.gitversion
 
 import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 import net.minecraftforge.gitver.api.GitVersion
 import net.minecraftforge.gitver.api.GitVersionException
 import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.annotations.Nullable
 
 import javax.inject.Inject
 
 /**
  * The heart of the Git Version Gradle plugin. This extension is responsible for creating the GitVersion object and
  * allowing access to it from Gradle buildscripts.
- * <p>
- * To avoid issues with Gradle's Configuration Cache, the system Git config is disabled using
- * {@link GitVersion#disableSystemConfig()}.
+ * <p>When using Gradle's Configuration Cache, the system Git config is disabled.</p>
  */
 @CompileStatic
+@SuppressWarnings('GrDeprecatedAPIUsage')
 class GitVersionExtension {
     public static final String NAME = 'gitversion'
 
     private final Project project
+    private final ObjectFactory objects
     private final ProjectLayout layout
+    private final ProviderFactory providers
+    private final BuildFeatures buildFeatures
 
-    /**
-     * The Git Version, created lazily with the {@linkplain GitVersion#disableSystemConfig() system config disabled} and
-     * the ability to recover from errors by creating a default version of 0.0.0.
-     */
-    @Lazy GitVersion version = {
-        GitVersion.disableSystemConfig()
+    /** @deprecated This constructor will be made package-private in GradleUtils 3.0 */
+    @Inject
+    @Deprecated(forRemoval = true)
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
+    GitVersionExtension(Project project, ObjectFactory objects, ProjectLayout layout, ProviderFactory providers, BuildFeatures buildFeatures) {
+        this.project = project
+        this.objects = objects
+        this.layout = layout
+        this.providers = providers
+        this.buildFeatures = buildFeatures
+    }
+
+
+    /* GIT VERSION */
+
+    @Deprecated(forRemoval = true)
+    @ApiStatus.ScheduledForRemoval(inVersion = '3.0')
+    @PackageScope @Lazy GitVersion versionInternal = {
+        // If we are using the configuration cache, disable the system config since it calls the git command line tool
+        if (this.buildFeatures.configurationCache.active.getOrElse(false))
+            GitVersion.disableSystemConfig()
 
         var builder = GitVersion.builder().project(this.layout.projectDirectory.asFile)
         try {
@@ -45,9 +74,121 @@ class GitVersionExtension {
         }
     }()
 
-    @Inject
-    GitVersionExtension(Project project, ProjectLayout layout) {
-        this.project = project
-        this.layout = layout
+    // TODO [GradleUtils][3.0] Make private
+    private static boolean deprecationWarning
+    @Deprecated(forRemoval = true)
+    GitVersion getVersion() {
+        if (!deprecationWarning) {
+            this.project.logger.warn "WARNING: The usage of 'gitversion.version' has been deprecated and will be removed in GradleUtils 3.0. Please remove the 'version' call (i.e. 'gitversion.version.tagOffset' -> 'gitversion.tagOffset')."
+            deprecationWarning = true
+        }
+
+        this.versionInternal
+    }
+
+
+    /* VERSION NUMBER */
+
+    String getTagOffset() {
+        this.versionInternal.tagOffset
+    }
+
+    String getTagOffsetBranch() {
+        this.versionInternal.tagOffsetBranch
+    }
+
+    String getTagOffsetBranch(String... allowedBranches) {
+        this.versionInternal.getTagOffsetBranch allowedBranches
+    }
+
+    String getTagOffsetBranch(Collection<String> allowedBranches) {
+        this.versionInternal.getTagOffsetBranch allowedBranches
+    }
+
+    String getMCTagOffsetBranch(String mcVersion) {
+        this.versionInternal.getMCTagOffsetBranch mcVersion
+    }
+
+    String getMCTagOffsetBranch(String mcVersion, String... allowedBranches) {
+        this.versionInternal.getMCTagOffsetBranch mcVersion, allowedBranches
+    }
+
+    String getMCTagOffsetBranch(String mcVersion, Collection<String> allowedBranches) {
+        this.versionInternal.getMCTagOffsetBranch mcVersion, allowedBranches
+    }
+
+
+    /* INFO */
+
+    GitVersion.Info getInfo() {
+        this.versionInternal.info
+    }
+
+    @Nullable String getUrl() {
+        this.versionInternal.url
+    }
+
+
+    /* FILE SYSTEM */
+
+    @Lazy DirectoryProperty gitDir = {
+        this.objects.directoryProperty().fileProvider(this.providers.provider {
+            this.versionInternal.gitDir
+        })
+    }()
+
+    @Lazy DirectoryProperty rootDir = {
+        this.objects.directoryProperty().fileProvider(this.providers.provider {
+            this.versionInternal.root
+        })
+    }()
+
+    @Lazy DirectoryProperty projectDir = {
+        this.objects.directoryProperty().fileProvider(this.providers.provider {
+            this.versionInternal.project
+        })
+    }()
+
+    @Lazy Property<String> projectPath = {
+        this.objects.property(String).value(this.providers.provider {
+            this.versionInternal.projectPath
+        })
+    }()
+
+    Provider<String> getRelativePath(FileSystemLocation file) {
+        this.getRelativePath this.providers.provider { file }
+    }
+
+    Provider<String> getRelativePath(Provider<? extends FileSystemLocation> file) {
+        this.providers.provider {
+            this.versionInternal.getRelativePath file.get().asFile
+        }
+    }
+
+
+    /* SUBPROJECTS */
+
+    @Lazy ListProperty<Directory> subprojects = {
+        this.objects.listProperty(Directory).value(this.providers.provider {
+            this.versionInternal.subprojects.collect {
+                dir -> this.layout.dir(this.providers.provider { dir }).get()
+            }
+        })
+    }()
+
+    private @Lazy ListProperty<String> subprojectPathsFromRoot = {
+        this.objects.listProperty(String).value(this.providers.provider {
+            this.versionInternal.getSubprojectPaths true
+        })
+    }()
+
+    @Lazy ListProperty<String> subprojectPaths = {
+        this.objects.listProperty(String).value(this.providers.provider {
+            this.versionInternal.subprojectPaths
+        })
+    }()
+
+    ListProperty<String> getSubprojectPaths(boolean fromRoot) {
+        fromRoot ? this.subprojectPathsFromRoot : this.subprojectPaths
     }
 }

--- a/src/main/groovy/net/minecraftforge/gradleutils/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/net/minecraftforge/gradleutils/gitversion/GitVersionPlugin.groovy
@@ -7,18 +7,28 @@ package net.minecraftforge.gradleutils.gitversion
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
 
 import javax.inject.Inject
 
 /** The entry point for the Git Version Gradle plugin. Exists to create the {@linkplain GitVersionExtension extension}. */
 @CompileStatic
 abstract class GitVersionPlugin implements Plugin<Project> {
-    @Inject
-    abstract ProjectLayout getLayout()
+    /** @see <a href="https://docs.gradle.org/current/userguide/service_injection.html#objectfactory">ObjectFactory Service Injection</a> */
+    @Inject abstract ObjectFactory getObjects()
+    /** @see <a href="https://docs.gradle.org/current/userguide/service_injection.html#sec:projectlayout">ProjectLayout Service Injection</a> */
+    @Inject abstract ProjectLayout getLayout()
+    /** @see <a href="https://docs.gradle.org/current/userguide/service_injection.html#providerfactory">ProviderFactory Service Injection</a> */
+    @Inject abstract ProviderFactory getProviders()
+    /** @see <a href="https://docs.gradle.org/current/userguide/implementing_gradle_plugins_binary.html#reacting_to_build_features">Reacting to build features</a> */
+    @Inject abstract BuildFeatures getBuildFeatures()
 
     @Override
     void apply(Project project) {
-        project.extensions.create(GitVersionExtension.NAME, GitVersionExtension, project, this.layout)
+        // TODO [GradleUtils][3.0][GitVersion] Use direct constructor
+        project.extensions.create(GitVersionExtension.NAME, GitVersionExtension, project, this.objects, this.layout, this.providers, this.buildFeatures)
     }
 }


### PR DESCRIPTION
If there are no complaints or concerns, I will squash and fast-forward this tagged `2.5` tomorrow. **This will be my last update to GU 2.x before beginning work on GU 3.x, which will strip out all deprecated features and split the plugins into subprojects.**

- Small buildscript cleanup.
- The `GitVersionExtension` class is now the public facing API for Git Version in the Gradle plugin.
  - Use `gitversion.tagOffset` instead of `gitversion.version.tagOffset`.
  - Many parts of Git Version API such as getting a directory now use Gradle's `DirectoryProperty` when applicable.
- If configuration cache is not requested, Git Version will not disable reading from the system's Git config.
- PomUtils cleanup.
  - `Developers` renamed to `developers` (now lowercase) to match `licenses`. The uppercase field will be removed in GU 3.0.
  - Licenses now use the SPDX identifier as the name and `repo` as the distribution, as recommended by the [reference spec](https://maven.apache.org/pom.html#Licenses).
- All-around code cleanup.
- Documentation is not a focus this time.