### PR TITLE
3.5 - ToolExecSpec/Operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,8 @@ plugins {
 gradleutils.displayName = 'Forge Gradle Utilities'
 description = "Small collection of utilities for standardizing Forge's buildscripts."
 group = 'net.minecraftforge'
-version = gitversion.tagOffset
+//version = gitversion.tagOffset
+version = '3.5.0'
 
 println "Version: $version"
 

--- a/gradleutils-shared/build.gradle
+++ b/gradleutils-shared/build.gradle
@@ -18,7 +18,8 @@ gradleutils.displayName = 'GradleUtils Shared'
 description = 'The shared base used by all of Forge\'s Gradle plugins.'
 base.archivesName = 'gradleutils-shared'
 group = 'net.minecraftforge'
-version = gitversion.tagOffset
+//version = gitversion.tagOffset
+version = '3.5.0'
 
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(17)

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedPlugin.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedPlugin.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Callable;
 /// needing to duplicate code across projects.
 ///
 /// @param <T> The type of target
-public non-sealed abstract class EnhancedPlugin<T> implements Plugin<T>, EnhancedPluginAdditions {
+public abstract non-sealed class EnhancedPlugin<T> implements Plugin<T>, EnhancedPluginAdditions {
     private final String name;
     private final String displayName;
     private final @Nullable String toolsExtName;

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedPluginAdditions.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedPluginAdditions.java
@@ -8,7 +8,7 @@ import org.gradle.api.file.DirectoryProperty;
 
 /// This interface defines the additional methods added by [EnhancedPlugin]. They are additionally accessible in tasks
 /// that implement [EnhancedTask].
-public sealed interface EnhancedPluginAdditions permits EnhancedPlugin, EnhancedTask {
+public sealed interface EnhancedPluginAdditions permits EnhancedPlugin, EnhancedTask, EnhancedTaskAdditions {
     /// Gets a provider to the file for a [Tool] to be used. The tool's state is managed by Gradle through the
     /// [org.gradle.api.provider.ValueSource] API and will not cause caching issues.
     ///

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedTask.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedTask.java
@@ -16,7 +16,7 @@ import org.gradle.api.tasks.Internal;
 /// The enhanced task contains a handful of helper methods to make working with the enhanced plugin and caches easier.
 ///
 /// @param <P> The type of enhanced problems
-public non-sealed interface EnhancedTask<P extends EnhancedProblems> extends Task, EnhancedPluginAdditions {
+public non-sealed interface EnhancedTask<P extends EnhancedProblems> extends Task, EnhancedPluginAdditions, EnhancedTaskAdditions {
     /// The enhanced plugin type for this task.
     ///
     /// @return The plugin type
@@ -27,70 +27,14 @@ public non-sealed interface EnhancedTask<P extends EnhancedProblems> extends Tas
     /// @return The problems type
     Class<P> problemsType();
 
-    private EnhancedPlugin<? super Project> getPlugin() {
+    @Override
+    default EnhancedPlugin<? super Project> plugin() {
         return this.getProject().getPlugins().getPlugin(this.pluginType());
     }
 
     @Override
-    default Tool.Resolved getTool(Tool tool) {
-        return this.getPlugin().getTool(tool);
-    }
-
-    @Override
-    default DirectoryProperty globalCaches() {
-        return this.getPlugin().globalCaches();
-    }
-
-    @Override
-    default DirectoryProperty localCaches() {
-        return this.getPlugin().localCaches();
-    }
-
-    @Override
-    default DirectoryProperty rootProjectDirectory() {
-        return this.getPlugin().rootProjectDirectory();
-    }
-
-    @Override
-    default DirectoryProperty workingProjectDirectory() {
-        return this.getPlugin().workingProjectDirectory();
-    }
-
-    /// The default output directory to use for this task if it outputs a directory.
-    ///
-    /// @return A provider for the directory
-    default @Internal Provider<Directory> getDefaultOutputDirectory() {
-        return this.localCaches().dir(this.getName()).map(this.getPlugin().getProblemsInternal().ensureFileLocation());
-    }
-
-    /// The default output file to use for this task if it outputs a file. Uses the `.jar` extension.
-    ///
-    /// @return A provider for the file
-    default @Internal Provider<RegularFile> getDefaultOutputFile() {
-        return this.getDefaultOutputFile("jar");
-    }
-
-    /// The default output file to use for this task if it outputs a file.
-    ///
-    /// @param ext The extension to use for the file
-    /// @return A provider for the file
-    default @Internal Provider<RegularFile> getDefaultOutputFile(String ext) {
-        return this.getOutputFile("output." + ext);
-    }
-
-    /// The default output log file to use for this task.
-    ///
-    /// @return A provider for the file
-    default @Internal Provider<RegularFile> getDefaultLogFile() {
-        return this.getOutputFile("log.txt");
-    }
-
-    /// A file with the specified name in the default output directory.
-    ///
-    /// @param fileName The name of the output file
-    /// @return A provider for the file
-    default @Internal Provider<RegularFile> getOutputFile(String fileName) {
-        return this.localCaches().file(String.format("%s/%s", this.getName(), fileName)).map(this.getPlugin().getProblemsInternal().ensureFileLocation());
+    default String baseName() {
+        return this.getName();
     }
 
     default void afterEvaluate(Action<? super Project> action) {

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedTaskAdditions.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedTaskAdditions.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.gradleutils.shared;
+
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Internal;
+
+sealed interface EnhancedTaskAdditions extends EnhancedPluginAdditions permits EnhancedTask, ToolExecSpec {
+    EnhancedPlugin<?> plugin();
+
+    String baseName();
+
+    default Tool.Resolved getTool(Tool tool) {
+        return this.plugin().getTool(tool);
+    }
+
+    default DirectoryProperty globalCaches() {
+        return this.plugin().globalCaches();
+    }
+
+    default DirectoryProperty localCaches() {
+        return this.plugin().localCaches();
+    }
+
+    default DirectoryProperty rootProjectDirectory() {
+        return this.plugin().rootProjectDirectory();
+    }
+
+    default DirectoryProperty workingProjectDirectory() {
+        return this.plugin().workingProjectDirectory();
+    }
+
+    /// The default output directory to use for this task if it outputs a directory.
+    ///
+    /// @return A provider for the directory
+    default @Internal Provider<Directory> getDefaultOutputDirectory() {
+        return this.localCaches().dir(this.baseName()).map(this.plugin().getProblemsInternal().ensureFileLocation());
+    }
+
+    /// The default output file to use for this task if it outputs a file. Uses the `.jar` extension.
+    ///
+    /// @return A provider for the file
+    default @Internal Provider<RegularFile> getDefaultOutputFile() {
+        return this.getDefaultOutputFile("jar");
+    }
+
+    /// The default output file to use for this task if it outputs a file.
+    ///
+    /// @param ext The extension to use for the file
+    /// @return A provider for the file
+    default @Internal Provider<RegularFile> getDefaultOutputFile(String ext) {
+        return this.getOutputFile("output." + ext);
+    }
+
+    /// The default output log file to use for this task.
+    ///
+    /// @return A provider for the file
+    default @Internal Provider<RegularFile> getDefaultLogFile() {
+        return this.getOutputFile("log.txt");
+    }
+
+    /// A file with the specified name in the default output directory.
+    ///
+    /// @param fileName The name of the output file
+    /// @return A provider for the file
+    default @Internal Provider<RegularFile> getOutputFile(String fileName) {
+        return this.localCaches().file(String.format("%s/%s", this.baseName(), fileName)).map(this.plugin().getProblemsInternal().ensureFileLocation());
+    }
+}

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/ToolExecArgumentsCollector.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/ToolExecArgumentsCollector.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.gradleutils.shared;
+
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.file.FileSystemLocationProperty;
+import org.gradle.api.provider.Provider;
+import org.jetbrains.annotations.UnknownNullability;
+
+import java.io.File;
+import java.util.Map;
+
+public interface ToolExecArgumentsCollector {
+    void args(Object... args);
+
+    void args(Iterable<?> args);
+
+    void args(String arg, Iterable<? extends File> files);
+
+    void args(String arg, FileSystemLocationProperty<? extends FileSystemLocation> fileProvider);
+
+    void args(String arg, @UnknownNullability Provider<?> provider);
+
+    void args(Map<?, ?> args);
+
+    void jvmArgs(Object... args);
+
+    void jvmArgs(Iterable<?> args);
+
+    void environment(String key, String value);
+
+    void systemProperty(String key, String value);
+}

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/ToolExecArgumentsCollectorImpl.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/ToolExecArgumentsCollectorImpl.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.gradleutils.shared;
+
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.file.FileSystemLocationProperty;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
+import org.gradle.api.provider.ProviderFactory;
+import org.jetbrains.annotations.UnknownNullability;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+abstract class ToolExecArgumentsCollectorImpl implements ToolExecArgumentsCollector {
+    final List<Provider<String>> args = new ArrayList<>();
+    final List<Provider<String>> jvmArgs = new ArrayList<>();
+    final Map<String, String> environment = new HashMap<>();
+    final Map<String, String> systemProperties = new HashMap<>();
+
+    protected abstract @Inject ProviderFactory getProviders();
+
+    @Inject
+    public ToolExecArgumentsCollectorImpl() { }
+
+    @Override
+    public void args(Object... args) {
+        this.args(Arrays.asList(args));
+    }
+
+    @Override
+    public void args(Iterable<?> args) {
+        try {
+            for (var arg : args) {
+                if (arg instanceof ProviderConvertible<?> providerConvertible)
+                    this.args.add(providerConvertible.asProvider().map(Object::toString));
+                if (arg instanceof Provider<?> provider)
+                    this.args.add(provider.map(Object::toString));
+                else
+                    this.args.add(this.getProviders().provider(arg::toString));
+            }
+        } catch (NullPointerException e) {
+            throw new IllegalStateException("ToolExecBase#jvmArgs can only be called inside of #addArguments()", e);
+        }
+    }
+
+    /// Adds each file to the arguments preceded by the given argument. Designed to work well with
+    /// <a href="https://jopt-simple.github.io/jopt-simple/">JOpt Simple</a>.
+    ///
+    /// @param arg   The flag to use for each file
+    /// @param files The files to add
+    @Override
+    public void args(String arg, Iterable<? extends File> files) {
+        for (File file : files)
+            this.args(arg, file);
+    }
+
+    /// Adds the given argument followed by the given file location to the arguments.
+    ///
+    /// @param arg          The flag to use
+    /// @param fileProvider The file to add
+    @Override
+    public void args(String arg, FileSystemLocationProperty<? extends FileSystemLocation> fileProvider) {
+        this.args(arg, fileProvider.getLocationOnly());
+    }
+
+    /// Adds the given argument followed by the given object (may be a file location) to the arguments.
+    ///
+    /// @param arg      The flag to use
+    /// @param provider The object (or file) to add
+    @Override
+    public void args(String arg, @UnknownNullability Provider<?> provider) {
+        if (provider == null || !provider.isPresent()) return;
+
+        // NOTE: We don't use File#getAbsoluteFile because path sensitivity should be handled by tasks.
+        var value = provider.map(it -> it instanceof FileSystemLocation ? ((FileSystemLocation) it).getAsFile() : it).getOrNull();
+        if (value == null) return;
+
+        if (value instanceof Boolean booleanValue) {
+            if (booleanValue)
+                this.args(arg);
+        } else {
+            this.args(arg, String.valueOf(value));
+        }
+    }
+
+    /// Adds the given map of arguments.
+    ///
+    /// [#args(String, Provider)] will be invoked for each entry in the map. If the key and/or value are not of the
+    /// required types, they will be automatically converted using [Object#toString()] and
+    /// [org.gradle.api.provider.ProviderFactory#provider(Callable)].
+    ///
+    /// @param args The args to add
+    /// @deprecated Too ambiguous with [#args(String, Provider)]. Prefer that method instead.
+    @Override
+    @Deprecated(forRemoval = true)
+    public void args(Map<?, ?> args) {
+        for (Map.Entry<?, ?> entry : args.entrySet()) {
+            var key = entry.getKey();
+            var value = entry.getValue();
+            this.args(
+                key instanceof Provider<?> provider ? provider.map(Object::toString).get() : this.getProviders().provider(key::toString).get(),
+                value instanceof Provider<?> provider ? (provider instanceof FileSystemLocationProperty<?> file ? file.getLocationOnly() : provider) : this.getProviders().provider(() -> value)
+            );
+        }
+    }
+
+    @Override
+    public void jvmArgs(Object... args) {
+        try {
+            for (var arg : args) {
+                this.jvmArgs.add(this.getProviders().provider(arg::toString));
+            }
+        } catch (NullPointerException e) {
+            throw new IllegalStateException("ToolExecBase#jvmArgs can only be called inside of #addArguments()", e);
+        }
+    }
+
+    @Override
+    public void jvmArgs(Iterable<?> args) {
+        try {
+            for (var arg : args) {
+                this.jvmArgs.add(this.getProviders().provider(arg::toString));
+            }
+        } catch (NullPointerException e) {
+            throw new IllegalStateException("ToolExecBase#jvmArgs can only be called inside of #addArguments()", e);
+        }
+    }
+
+    @Override
+    public void environment(String key, String value) {
+        try {
+            this.environment.put(key, value);
+        } catch (NullPointerException e) {
+            throw new IllegalStateException("ToolExecBase#environment can only be called inside of #addArguments()", e);
+        }
+    }
+
+    @Override
+    public void systemProperty(String key, String value) {
+        try {
+            this.systemProperties.put(key, value);
+        } catch (NullPointerException e) {
+            throw new IllegalStateException("ToolExecBase#systemProperty can only be called inside of #addArguments()", e);
+        }
+    }
+}

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/ToolExecOperations.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/ToolExecOperations.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.gradleutils.shared;
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.process.ExecResult;
+
+import javax.inject.Inject;
+
+public abstract class ToolExecOperations {
+    protected abstract @Inject ObjectFactory getObjects();
+
+    private final Plugin<? extends EnhancedPlugin<?>> plugin;
+
+    @Inject
+    public ToolExecOperations(Plugin<? extends EnhancedPlugin<?>> plugin) {
+        this.plugin = plugin;
+    }
+
+    public ExecResult toolexec(Tool tool, Action<? super ToolExecSpec> action) {
+        var spec = getObjects().newInstance(ToolExecSpec.class, plugin, tool);
+        action.execute(spec);
+        return spec.exec();
+    }
+}

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/ToolExecSpec.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/ToolExecSpec.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.gradleutils.shared;
+
+import groovy.lang.Closure;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+import org.gradle.api.artifacts.dsl.DependencyFactory;
+import org.gradle.api.artifacts.dsl.ExternalModuleDependencyVariantSpec;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.file.FileSystemLocationProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Console;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
+import org.gradle.process.JavaExecSpec;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public abstract non-sealed class ToolExecSpec implements EnhancedTaskAdditions {
+    private static final Logger LOGGER = Logging.getLogger(ToolExecSpec.class);
+
+    //region JavaExec
+    public abstract @InputFiles @Classpath ConfigurableFileCollection getClasspath();
+
+    public abstract @Input @Optional Property<String> getMainClass();
+
+    public abstract @Nested Property<JavaLauncher> getJavaLauncher();
+
+    protected abstract @Nested Property<JavaLauncher> getToolchainLauncher();
+
+    public abstract @Input @Optional Property<Boolean> getPreferToolchainJvm();
+
+    public abstract @Internal DirectoryProperty getWorkingDir();
+
+    protected abstract @Internal MapProperty<String, String> getForkProperties();
+    //endregion
+
+    //region JavaExec Arguments
+    protected abstract @Input @Optional ListProperty<String> getArgs();
+
+    protected abstract @Input @Optional ListProperty<String> getJvmArgs();
+
+    protected abstract @Input @Optional MapProperty<String, String> getEnvironment();
+
+    protected abstract @Input @Optional MapProperty<String, String> getSystemProperties();
+    //endregion
+
+    //region Logging
+    protected abstract @Console Property<LogLevel> getStandardOutputLogLevel();
+
+    protected abstract @Console Property<LogLevel> getStandardErrorLogLevel();
+
+    protected abstract @Internal RegularFileProperty getLogFile();
+    //endregion
+
+    @Override
+    public EnhancedPlugin<?> plugin() {
+        return this.plugin;
+    }
+
+    protected abstract @Inject Project getProject();
+
+    protected abstract @Inject ObjectFactory getObjects();
+
+    protected abstract @Inject ProviderFactory getProviders();
+
+    protected abstract @Inject ExecOperations getExecOperations();
+
+    protected abstract @Inject DependencyFactory getDependencyFactory();
+
+    protected abstract @Inject JavaToolchainService getJavaToolchains();
+
+    private final transient EnhancedPlugin<?> plugin;
+    private final String toolName;
+
+    //private Closure<Void> javaexecAction = Closures.<JavaExecSpec>consumer(it -> { });
+
+    private transient @Nullable List<Provider<String>> overflowArgs;
+    private transient @Nullable List<Provider<String>> overflowJvmArgs;
+    private transient @Nullable Map<String, String> overflowEnvironment;
+    private transient @Nullable Map<String, String> overflowSystemProperties;
+
+    private void addArgs(Provider<String> provider) {
+        if (this.overflowArgs != null) {
+            this.overflowArgs.add(provider);
+            return;
+        }
+
+        try {
+            this.getArgs().add(provider);
+        } catch (IllegalStateException e) {
+            this.overflowArgs = new ArrayList<>();
+            this.overflowArgs.add(provider);
+        }
+    }
+
+    private void addJvmArgs(Provider<String> provider) {
+        if (this.overflowJvmArgs != null) {
+            this.overflowJvmArgs.add(provider);
+            return;
+        }
+
+        try {
+            this.getJvmArgs().add(provider);
+        } catch (IllegalStateException e) {
+            this.overflowJvmArgs = new ArrayList<>();
+            this.overflowJvmArgs.add(provider);
+        }
+    }
+
+    private void putEnvironment(String key, String value) {
+        if (this.overflowEnvironment != null) {
+            this.overflowEnvironment.put(key, value);
+            return;
+        }
+
+        try {
+            this.getEnvironment().put(key, value);
+        } catch (IllegalStateException e) {
+            this.overflowEnvironment = new HashMap<>();
+            this.overflowEnvironment.put(key, value);
+        }
+    }
+
+    private void putSystemProperties(String key, String value) {
+        if (this.overflowSystemProperties != null) {
+            this.overflowSystemProperties.put(key, value);
+            return;
+        }
+
+        try {
+            this.getSystemProperties().put(key, value);
+        } catch (IllegalStateException e) {
+            this.overflowSystemProperties = new HashMap<>();
+            this.overflowSystemProperties.put(key, value);
+        }
+    }
+
+    @Inject
+    public ToolExecSpec(EnhancedPlugin<?> plugin, Tool.Resolved resolved) {
+        this.plugin = plugin;
+        this.toolName = resolved.getName();
+        this.getClasspath().convention(resolved.getClasspath());
+
+        if (resolved.hasMainClass())
+            this.getMainClass().set(resolved.getMainClass());
+        this.getJavaLauncher().set(resolved.getJavaLauncher());
+
+        try {
+            this.getToolchainLauncher().convention(getJavaToolchains().launcherFor(spec -> spec.getLanguageVersion().set(JavaLanguageVersion.current())));
+            getProject().getPluginManager().withPlugin("java", javaAppliedPlugin ->
+                this.getToolchainLauncher().set(getJavaToolchains().launcherFor(getProject().getExtensions().getByType(JavaPluginExtension.class).getToolchain()))
+            );
+        } catch (Exception ignored) {
+            // If these fail, we're likely in a Settings environment
+            // This is fine, we can just try using the Daemon JVM
+        }
+
+        this.getForkProperties().set(SharedUtil.getForkProperties(getProviders()));
+
+        this.getStandardOutputLogLevel().convention(LogLevel.LIFECYCLE);
+        this.getStandardErrorLogLevel().convention(LogLevel.ERROR);
+
+        this.getWorkingDir().convention(this.getDefaultOutputDirectory());
+        this.getLogFile().convention(this.getDefaultLogFile());
+    }
+
+    public final void using(CharSequence dependency) {
+        this.using(getDependencyFactory().create(dependency));
+    }
+
+    public final void using(Provider<? extends Dependency> dependency) {
+        this.getClasspath().setFrom(
+            getProject().getConfigurations().detachedConfiguration().withDependencies(d -> d.addLater(dependency))
+        );
+    }
+
+    public final void using(Provider<MinimalExternalModuleDependency> dependency, Action<? super ExternalModuleDependencyVariantSpec> variantSpec) {
+        this.using(getProject().getDependencies().variantOf(dependency, variantSpec));
+    }
+
+    public final void using(ProviderConvertible<? extends Dependency> dependency) {
+        this.using(dependency.asProvider());
+    }
+
+    public final void using(ProviderConvertible<MinimalExternalModuleDependency> dependency, Action<? super ExternalModuleDependencyVariantSpec> variantSpec) {
+        this.using(getProject().getDependencies().variantOf(dependency, variantSpec));
+    }
+
+    public final void using(Dependency dependency) {
+        this.getClasspath().setFrom(
+            getProject().getConfigurations().detachedConfiguration(dependency)
+        );
+    }
+
+    @Deprecated
+    public final void usingDirectly(CharSequence downloadUrl) {
+        var url = getProviders().provider(downloadUrl::toString);
+        this.getClasspath().setFrom(getProviders().of(ToolImpl.Source.class, spec -> spec.parameters(parameters -> {
+            parameters.getInputFile().set(getProviders().zip(localCaches(), url, (d, s) -> d.file("tools/" + toolName + '/' + s.substring(s.lastIndexOf('/')))));
+            parameters.getDownloadUrl().set(url);
+        })));
+    }
+
+    private <T extends FileSystemLocation> Transformer<T, T> ensureFileLocationInternal() {
+        return t -> this.plugin.getProblemsInternal().<T>ensureFileLocation().transform(t);
+    }
+
+    protected ExecResult exec() throws IOException {
+        var args = this.getArgs().getOrElse(List.of());
+        if (this.overflowArgs != null)
+            args.addAll(DefaultGroovyMethods.collect(this.overflowArgs, Closures.<Provider<String>, String>function(Provider::get)));
+
+        var jvmArgs = this.getJvmArgs().getOrElse(List.of());
+        if (this.overflowJvmArgs != null)
+            jvmArgs.addAll(DefaultGroovyMethods.collect(this.overflowJvmArgs, Closures.<Provider<String>, String>function(Provider::get)));
+
+        var environment = new HashMap<>(this.getEnvironment().getOrElse(Map.of()));
+        if (this.overflowEnvironment != null)
+            environment.putAll(this.overflowEnvironment);
+
+        var systemProperties = new HashMap<>(this.getSystemProperties().getOrElse(Map.of()));
+        if (this.overflowSystemProperties != null)
+            systemProperties.putAll(this.overflowSystemProperties);
+        for (var property : this.getForkProperties().get().entrySet())
+            systemProperties.putIfAbsent(property.getKey(), property.getValue());
+
+        var stdOutLevel = this.getStandardOutputLogLevel().get();
+        var stdErrLevel = this.getStandardErrorLogLevel().get();
+
+        JavaLauncher javaLauncher;
+        if (getPreferToolchainJvm().getOrElse(false)) {
+            var candidateLauncher = getJavaLauncher().get();
+            var toolchainLauncher = getToolchainLauncher().get();
+            javaLauncher = toolchainLauncher.getMetadata().getLanguageVersion().canCompileOrRun(candidateLauncher.getMetadata().getLanguageVersion())
+                ? toolchainLauncher
+                : candidateLauncher;
+        } else {
+            javaLauncher = getJavaLauncher().get();
+        }
+
+        var workingDirectory = this.getWorkingDir().map(ensureFileLocationInternal()).get().getAsFile();
+
+        try (var log = new PrintWriter(new FileWriter(this.getLogFile().getAsFile().get()), true)) {
+            return getExecOperations().javaexec(spec -> {
+                spec.setIgnoreExitValue(true);
+
+                spec.setWorkingDir(workingDirectory);
+                spec.setClasspath(this.getClasspath());
+                if (this.getMainClass().isPresent())
+                    spec.getMainClass().set(this.getMainClass());
+                spec.setExecutable(javaLauncher.getExecutablePath().getAsFile().getAbsolutePath());
+                spec.setArgs(args);
+                spec.setJvmArgs(jvmArgs);
+                spec.setEnvironment(environment);
+                spec.setSystemProperties(systemProperties);
+
+                spec.setStandardOutput(SharedUtil.toLog(
+                    line -> {
+                        LOGGER.log(stdOutLevel, line);
+                        log.println(line);
+                    }
+                ));
+                spec.setErrorOutput(SharedUtil.toLog(
+                    line -> {
+                        LOGGER.log(stdErrLevel, line);
+                        log.println(line);
+                    }
+                ));
+
+                log.print("Java Launcher: ");
+                log.println(spec.getExecutable());
+                log.print("Working directory: ");
+                log.println(spec.getWorkingDir().getAbsolutePath());
+                log.print("Main class: ");
+                log.println(spec.getMainClass().getOrElse("AUTOMATIC"));
+                log.println("Arguments:");
+                for (var s : spec.getArgs()) {
+                    log.print("  ");
+                    log.println(s);
+                }
+                log.println("JVM Arguments:");
+                for (var s : spec.getAllJvmArgs()) {
+                    log.print("  ");
+                    log.println(s);
+                }
+                log.println("Classpath:");
+                for (var f : getClasspath()) {
+                    log.print("  ");
+                    log.println(f.getAbsolutePath());
+                }
+                log.println("====================================");
+            });
+        }
+    }
+
+    public void args(Object... args) {
+        this.args(Arrays.asList(args));
+    }
+
+    public void args(Iterable<?> args) {
+        for (var arg : args) {
+            if (arg instanceof ProviderConvertible<?> providerConvertible)
+                this.addArgs(providerConvertible.asProvider().map(Object::toString));
+            if (arg instanceof Provider<?> provider)
+                this.addArgs(provider.map(Object::toString));
+            else
+                this.addArgs(this.getProviders().provider(arg::toString));
+        }
+    }
+
+    /// Adds each file to the arguments preceded by the given argument. Designed to work well with
+    /// <a href="https://jopt-simple.github.io/jopt-simple/">JOpt Simple</a>.
+    ///
+    /// @param arg   The flag to use for each file
+    /// @param files The files to add
+    public void args(String arg, Iterable<? extends File> files) {
+        for (File file : files)
+            this.args(arg, file);
+    }
+
+    /// Adds the given argument followed by the given file location to the arguments.
+    ///
+    /// @param arg          The flag to use
+    /// @param fileProvider The file to add
+    public void args(String arg, FileSystemLocationProperty<? extends FileSystemLocation> fileProvider) {
+        this.args(arg, fileProvider.getLocationOnly());
+    }
+
+    /// Adds the given argument followed by the given object (may be a file location) to the arguments.
+    ///
+    /// @param arg      The flag to use
+    /// @param provider The object (or file) to add
+    public void args(String arg, @UnknownNullability Provider<?> provider) {
+        if (provider == null || !provider.isPresent()) return;
+
+        // NOTE: We don't use File#getAbsoluteFile because path sensitivity should be handled by tasks.
+        var value = provider.map(it -> it instanceof FileSystemLocation ? ((FileSystemLocation) it).getAsFile() : it).getOrNull();
+        if (value == null) return;
+
+        if (value instanceof Boolean booleanValue) {
+            if (booleanValue)
+                this.args(arg);
+        } else {
+            this.args(arg, String.valueOf(value));
+        }
+    }
+
+    /// Adds the given map of arguments.
+    ///
+    /// [#args(String, Provider)] will be invoked for each entry in the map. If the key and/or value are not of the
+    /// required types, they will be automatically converted using [Object#toString()] and
+    /// [org.gradle.api.provider.ProviderFactory#provider(Callable)].
+    ///
+    /// @param args The args to add
+    /// @deprecated Too ambiguous with [#args(String, Provider)]. Prefer that method instead.
+    @Deprecated(forRemoval = true)
+    public void args(Map<?, ?> args) {
+        for (Map.Entry<?, ?> entry : args.entrySet()) {
+            var key = entry.getKey();
+            var value = entry.getValue();
+            this.args(
+                key instanceof Provider<?> provider ? provider.map(Object::toString).get() : this.getProviders().provider(key::toString).get(),
+                value instanceof Provider<?> provider ? (provider instanceof FileSystemLocationProperty<?> file ? file.getLocationOnly() : provider) : this.getProviders().provider(() -> value)
+            );
+        }
+    }
+
+    public void jvmArgs(Object... args) {
+        for (var arg : args) {
+            this.addJvmArgs(this.getProviders().provider(arg::toString));
+        }
+    }
+
+    public void jvmArgs(Iterable<?> args) {
+        for (var arg : args) {
+            this.addJvmArgs(this.getProviders().provider(arg::toString));
+        }
+    }
+
+    public void environment(String key, String value) {
+        this.putEnvironment(key, value);
+    }
+
+    public void systemProperty(String key, String value) {
+        this.putSystemProperties(key, value);
+    }
+}


### PR DESCRIPTION
This PR adds `ToolExecSpec` and `ToolExecOperations`.

`ToolExecSpec` is designed to be a nested task input property to remove additional clutter in tasks that need to use the GradleUtils Shared tool system to execute tools.

`ToolExecOperations` will be an abstract class, similar to `ExecOperations` that is instantiated through an `ObjectFactory` instead of through a service injection. The idea is for it to behave similarly to it, and it is what `ToolExecSpec` will likely end up using.

The purpose of this is to remove need to depend on `ToolExecBase` for various tasks, although it will continue to exist for sake of convenience.