### PR TITLE
Support Gradle's Isolated Projects feature in EnhancedPluginAdditions#rootProjectDirectory()

### DIFF
--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedPlugin.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedPlugin.java
@@ -221,7 +221,7 @@ public non-sealed abstract class EnhancedPlugin<T> implements Plugin<T>, Enhance
         try {
             var rootProjectDirectory = this.getObjects().directoryProperty();
             if (target instanceof Project project) {
-                return rootProjectDirectory.value(project.getRootProject().getLayout().getProjectDirectory());
+                return rootProjectDirectory.value(project.getIsolated().getRootProject().getProjectDirectory());
             } else if (target instanceof Settings) {
                 return rootProjectDirectory.value(this.getBuildLayout().getRootDirectory());
             } else {

--- a/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedPluginAdditions.java
+++ b/gradleutils-shared/src/main/java/net/minecraftforge/gradleutils/shared/EnhancedPluginAdditions.java
@@ -38,10 +38,12 @@ public sealed interface EnhancedPluginAdditions permits EnhancedPlugin, Enhanced
 
     /// Gets the root project directory to be used for this plugin.
     ///
-    /// This directory is either the [org.gradle.api.file.ProjectLayout#getProjectDirectory()] of
-    /// [org.gradle.api.Project#getRootProject()] or the [org.gradle.api.file.BuildLayout#getRootDirectory()] of the
-    /// [org.gradle.api.initialization.Settings]. Attempting to call this when the plugin target is neither type will
-    /// throw an exception.
+    /// This directory is either the root project's [org.gradle.api.project.IsolatedProject#getProjectDirectory()]
+    /// (via [org.gradle.api.Project#getIsolated()]) or the [org.gradle.api.file.BuildLayout#getRootDirectory()] of the
+    /// [org.gradle.api.initialization.Settings]. The isolated view is used instead of
+    /// [org.gradle.api.Project#getRootProject()] so this remains compatible with Isolated Projects without treating the
+    /// settings directory as the root project directory. Attempting to call this when the plugin target is neither type
+    /// will throw an exception.
     ///
     /// @return The root project directory
     /// @throws RuntimeException If this plugin cannot access the root project directory (i.e. the target is not


### PR DESCRIPTION
Prerequisite for https://github.com/MinecraftForge/ForgeGradle/issues/1083

[Using the isolated project API recommended by Gradle](https://docs.gradle.org/current/userguide/isolated_projects.html#sec:isolated_project_api) instead of grabbing the settings directory as this is a more direct replacement - there are edge-cases where the settings directory may differ from the root project's directory.